### PR TITLE
Location summary table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added view for a well location
 - Added cooperator logos to well location view
+- Added summary table to location view

--- a/server/ngwmn/__init__.py
+++ b/server/ngwmn/__init__.py
@@ -17,3 +17,4 @@ except FileNotFoundError:
 
 from . import views  # pylint: disable=C0413
 from . import filters  # pylint: disable=C0413
+from . import services  # pylint: disable=C0413

--- a/server/ngwmn/services/__init__.py
+++ b/server/ngwmn/services/__init__.py
@@ -4,6 +4,11 @@ from ngwmn import app
 
 
 class ServiceException(Exception):
+    """
+    Exception to be raised by external-service calls when an service error is
+    encountered. This exception will be passed to the end-user in the form of
+    a response with the given status code, message, and dict payload.
+    """
     def __init__(self, message=None, status_code=503, payload=None):
         super(ServiceException, self).__init__()
         self.message = message or 'error in backing service'
@@ -11,14 +16,21 @@ class ServiceException(Exception):
         self.payload = payload or {}
 
     def to_dict(self):
+        """
+        Convert this exception into a dictionary.
+        """
         return {
             **self.payload,
-            'message': self.message
+            'message': self.message,
+            'status_code': self.status_code
         }
 
 
 @app.errorhandler(ServiceException)
 def handle_service_exception(error):
+    """
+    Capture raised ServiceExceptions and return the appropriate status code.
+    """
     response = jsonify(error.to_dict())
     response.status_code = error.status_code
     return response

--- a/server/ngwmn/services/__init__.py
+++ b/server/ngwmn/services/__init__.py
@@ -1,0 +1,24 @@
+from flask import jsonify
+
+from ngwmn import app
+
+
+class ServiceException(Exception):
+    def __init__(self, message=None, status_code=503, payload=None):
+        super(ServiceException, self).__init__()
+        self.message = message or 'error in backing service'
+        self.status_code = status_code
+        self.payload = payload or {}
+
+    def to_dict(self):
+        return {
+            **self.payload,
+            'message': self.message
+        }
+
+
+@app.errorhandler(ServiceException)
+def handle_service_exception(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response

--- a/server/ngwmn/services/ngwmn.py
+++ b/server/ngwmn/services/ngwmn.py
@@ -34,10 +34,13 @@ def get_well_lithography(agency_cd, location_id, service_root=SERVICE_ROOT):
 
     resp = r.get(lithography_target, params=query_params)
 
-    if resp.status_code == 200:
-        return parse_xml(resp.content)
+    if resp.status_code == 404:
+        return None
 
-    raise ServiceException()
+    if resp.status_code != 200:
+        raise ServiceException()
+
+    return parse_xml(resp.content)
 
 
 def generate_bounding_box_values(latitude, longitude, delta=0.01):
@@ -82,11 +85,7 @@ def get_features(latitude, longitude, service_root=SERVICE_ROOT):
     target = urljoin(service_root, 'ngwmn/geoserver/wfs')
     response = r.post(target, params=params, data=data)
 
-    if response.status_code == 200:
-        return response.json()
-    elif 400 <= response.status_code < 500:
-        raise ServiceException(status_code=200)
-    elif 500 <= response.status_code <= 511:
+    if response.status_code != 200:
         raise ServiceException(message=response.reason)
-    else:
-        raise ServiceException(status_code=500)
+
+    return response.json()

--- a/server/ngwmn/services/ngwmn.py
+++ b/server/ngwmn/services/ngwmn.py
@@ -38,6 +38,8 @@ def get_well_lithography(agency_cd, location_id, service_root=SERVICE_ROOT):
         return None
 
     if resp.status_code != 200:
+        msg = '%s error from %s (reason: %s)'
+        app.logger.error(msg, resp.status_code, resp.url, resp.reason)
         raise ServiceException()
 
     return parse_xml(resp.content)
@@ -86,6 +88,6 @@ def get_features(latitude, longitude, service_root=SERVICE_ROOT):
     response = r.post(target, params=params, data=data)
 
     if response.status_code != 200:
-        raise ServiceException(message=response.reason)
+        raise ServiceException()
 
     return response.json()

--- a/server/ngwmn/services/ngwmn.py
+++ b/server/ngwmn/services/ngwmn.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 
 import requests as r
 
-from .xml_utils import parse_xml
+from ..xml_utils import parse_xml
 
 
 def get_well_lithography(service_root, agency_cd, location_id):

--- a/server/ngwmn/services/sifta.py
+++ b/server/ngwmn/services/sifta.py
@@ -18,7 +18,7 @@ def get_cooperators(site_no):
     try:
         response = requests.get(url)
     except requests.exceptions.RequestException as err:
-        app.logger.debug(str(err))
+        app.logger.error(str(err))
         return []
 
     # Gracefully degrade to an empty list of cooperators

--- a/server/ngwmn/templates/well_location.html
+++ b/server/ngwmn/templates/well_location.html
@@ -4,11 +4,7 @@
 {% set body_id = 'well-location' %}
 
 {% block content %}
-    {% if location_name %}
-        <h1>{{ location_name }}</h1>
-    {% else %}
-        <p>Service call failed with {{ status_code }}: {{ reason }}</p>
-    {% endif %}
+    <h1>{{ location_name }}</h1>
     {% if cooperators %}
         <div>
             <p>Operated in cooperation with:</p>

--- a/server/ngwmn/templates/well_location.html
+++ b/server/ngwmn/templates/well_location.html
@@ -1,10 +1,67 @@
 {% extends 'base.html' %}
 
-{% set page_title = location_name %}
+{% set page_title = feature.SITE_NAME %}
 {% set body_id = 'well-location' %}
 
+{% macro _(value) -%}
+    {{ value if value is not none else '-' }}
+{%- endmacro %}
+
 {% block content %}
-    <h1>{{ location_name }}</h1>
+    <h1>{{ feature.SITE_NAME }}</h1>
+    <table class="usa-table-borderless">
+        <caption>Summary</caption>
+        <tbody>
+            <tr>
+                <td scope="row">Agency</td>
+                <td>{{ _(feature.AGENCY_NM) }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Site Name</td>
+                <td>{{ _(feature.SITE_NAME) }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Site Number</td>
+                <td>{{ _(feature.SITE_NO) }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Site Type</td>
+                <td>{{ _(feature.SITE_TYPE) }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Lat/Long ({{ feature.HORZ_DATUM }})</td>
+                <td>{{ _(feature.DEC_LAT_VA) }}, {{ feature.DEC_LONG_VA }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Well Depth</td>
+                <td>{{ _(feature.WELL_DEPTH) }} {{ feature.WELL_DEPTH_UNITS_NM }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Local Aquifer Name</td>
+                <td>{{ _(feature.LOCAL_AQUIFER_NAME) }} ({{ feature.LOCAL_AQUIFER_CD }})</td>
+            </tr>
+            <tr>
+                <td scope="row">National Aquifer Name</td>
+                <td>{{ _(feature.NAT_AQFR_DESC) }} ({{ feature.NAT_AQUIFER_CD }})</td>
+            </tr>
+            <tr>
+                <td scope="row">Aquifer Type</td>
+                <td>{{ _(feature.AQFR_CHAR) }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Water Level Network</td>
+                <td>{{ _(feature.WL_SYS_NAME) }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Water Quality Network</td>
+                <td>{{ _(feature.QW_SYS_NAME) }}</td>
+            </tr>
+            <tr>
+                <td scope="row">Additional info</td>
+                <td><a href="{{ feature.LINK }}">Link</a></td>
+            </tr>
+        </tbody>
+    </table>
     {% if cooperators %}
         <div>
             <p>Operated in cooperation with:</p>

--- a/server/ngwmn/tests/services/test_ngwmn.py
+++ b/server/ngwmn/tests/services/test_ngwmn.py
@@ -6,6 +6,7 @@ from unittest import TestCase, mock
 
 import requests as r
 
+from ngwmn.services import ServiceException
 from ngwmn.services.ngwmn import generate_bounding_box_values, get_well_lithography
 
 
@@ -23,7 +24,7 @@ class TestGetWellLithography(TestCase):
         m_resp.content = self.test_xml
         m_resp.status_code = 200
         r_mock.return_value = m_resp
-        result = get_well_lithography(self.test_service_root, self.test_agency_cd, self.test_location_id)
+        result = get_well_lithography(self.test_agency_cd, self.test_location_id, self.test_service_root)
         self.assertEqual(result.tag, 'site')
         r_mock.assert_called_with(
             'http://fake.gov/ngwmn/iddata',
@@ -35,8 +36,9 @@ class TestGetWellLithography(TestCase):
         m_resp = mock.Mock(r.Response)
         m_resp.status_code = 500
         r_mock.return_value = m_resp
-        result = get_well_lithography(self.test_service_root, self.test_agency_cd, self.test_location_id)
-        self.assertIsNone(result)
+        with self.assertRaises(ServiceException):
+            result = get_well_lithography(self.test_agency_cd, self.test_location_id, self.test_service_root)
+            self.assertIsNone(result)
 
     @mock.patch('ngwmn.services.ngwmn.r.get')
     def test_syntax_error(self, r_mock):
@@ -44,7 +46,7 @@ class TestGetWellLithography(TestCase):
         m_resp.content = 'Stuff'
         m_resp.status_code = 200
         r_mock.return_value = m_resp
-        result = get_well_lithography(self.test_service_root, self.test_agency_cd, self.test_location_id)
+        result = get_well_lithography(self.test_agency_cd, self.test_location_id, self.test_service_root)
         self.assertIsNone(result)
 
 

--- a/server/ngwmn/tests/services/test_ngwmn.py
+++ b/server/ngwmn/tests/services/test_ngwmn.py
@@ -6,7 +6,7 @@ from unittest import TestCase, mock
 
 import requests as r
 
-from ..fetch_utils import generate_bounding_box_values, get_well_lithography
+from ngwmn.services.ngwmn import generate_bounding_box_values, get_well_lithography
 
 
 class TestGetWellLithography(TestCase):
@@ -17,7 +17,7 @@ class TestGetWellLithography(TestCase):
         self.test_location_id = 'BP-1729'
         self.test_xml = '<site><agency>DOOP</agency><id>BP-1729</id></site>'
 
-    @mock.patch('ngwmn.fetch_utils.r.get')
+    @mock.patch('ngwmn.services.ngwmn.r.get')
     def test_success(self, r_mock):
         m_resp = mock.Mock(r.Response)
         m_resp.content = self.test_xml
@@ -30,7 +30,7 @@ class TestGetWellLithography(TestCase):
             params={'request': 'well_log', 'agency_cd': 'DOOP', 'siteNo': 'BP-1729'}
         )
 
-    @mock.patch('ngwmn.fetch_utils.r.get')
+    @mock.patch('ngwmn.services.ngwmn.r.get')
     def test_service_failure(self, r_mock):
         m_resp = mock.Mock(r.Response)
         m_resp.status_code = 500
@@ -38,7 +38,7 @@ class TestGetWellLithography(TestCase):
         result = get_well_lithography(self.test_service_root, self.test_agency_cd, self.test_location_id)
         self.assertIsNone(result)
 
-    @mock.patch('ngwmn.fetch_utils.r.get')
+    @mock.patch('ngwmn.services.ngwmn.r.get')
     def test_syntax_error(self, r_mock):
         m_resp = mock.Mock(r.Response)
         m_resp.content = 'Stuff'

--- a/server/ngwmn/tests/services/test_ngwmn.py
+++ b/server/ngwmn/tests/services/test_ngwmn.py
@@ -35,6 +35,8 @@ class TestGetWellLithography(TestCase):
     def test_service_failure(self, r_mock):
         m_resp = mock.Mock(r.Response)
         m_resp.status_code = 500
+        m_resp.url = 'http://url'
+        m_resp.reason = 'reason'
         r_mock.return_value = m_resp
         with self.assertRaises(ServiceException):
             result = get_well_lithography(self.test_agency_cd, self.test_location_id, self.test_service_root)

--- a/server/ngwmn/tests/test_views.py
+++ b/server/ngwmn/tests/test_views.py
@@ -49,7 +49,7 @@ class TestWellPageView(TestCase):
 
         response = self.app_client.get('/well-location/{}/{}/'.format(self.test_agency_cd, self.test_location_id))
         post_mock.assert_called_once()
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 503)
 
     @mock.patch('ngwmn.services.ngwmn.r.post')
     @mock.patch('ngwmn.views.get_well_lithography')

--- a/server/ngwmn/tests/test_views.py
+++ b/server/ngwmn/tests/test_views.py
@@ -48,7 +48,7 @@ class TestWellPageView(TestCase):
         post_mock.return_value = post_resp
 
         response = self.app_client.get('/well-location/{}/{}/'.format(self.test_agency_cd, self.test_location_id))
-        well_lith_mock.assert_called_once()
+        post_mock.assert_called_once()
         self.assertEqual(response.status_code, 200)
 
     @mock.patch('ngwmn.services.ngwmn.r.post')

--- a/server/ngwmn/tests/test_views.py
+++ b/server/ngwmn/tests/test_views.py
@@ -2,6 +2,7 @@
 Unit tests for NGWMN views
 
 """
+import json
 from unittest import TestCase, mock
 
 from defusedxml.lxml import fromstring
@@ -20,17 +21,15 @@ class TestWellPageView(TestCase):
             '<wfs xmlns:gml="http://www.opengis.net/gml"><gml:Point srsName="EPSG:4269">'
             '<gml:pos srsDimension="2">39.443328281 -75.634096999</gml:pos></gml:Point></wfs>'
         )
-        self.test_summary_xml = (
-            '<wfs xmlns:ngwmn="gov.usgs.cida.ngwmn"><ngwmn:VW_GWDP_GEOSERVER>'
-            '<ngwmn:SITE_NAME>Water Farm 1</ngwmn:SITE_NAME></ngwmn:VW_GWDP_GEOSERVER></wfs>'
-        )
+        self.test_summary_json = '{"features": [{"properties": {"SITE_NAME": "site name"}}]}'
 
-    @mock.patch('ngwmn.views.r.post')
+    @mock.patch('ngwmn.services.ngwmn.r.post')
     @mock.patch('ngwmn.views.get_well_lithography')
     def test_best_case(self, well_lith_mock, post_mock):
         well_lith_mock.return_value = fromstring(self.test_well_xml)
         post_resp = mock.Mock(r.Response)
-        post_resp.content = self.test_summary_xml
+        post_resp.content = self.test_summary_json
+        post_resp.json.return_value = json.loads(self.test_summary_json)
         post_resp.status_code = 200
         post_mock.return_value = post_resp
 
@@ -38,27 +37,28 @@ class TestWellPageView(TestCase):
         post_mock.assert_called_once()
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('ngwmn.views.r.post')
+    @mock.patch('ngwmn.services.ngwmn.r.post')
     @mock.patch('ngwmn.views.get_well_lithography')
     def test_failed_service_with_non_server_error(self, well_lith_mock, post_mock):
         well_lith_mock.return_value = fromstring(self.test_well_xml)
         post_resp = mock.Mock(r.Response)
-        post_resp.content = self.test_summary_xml
+        post_resp.content = self.test_summary_json
         post_resp.status_code = 403
         post_resp.reason = 'Forbidden'
         post_mock.return_value = post_resp
 
         response = self.app_client.get('/well-location/{}/{}/'.format(self.test_agency_cd, self.test_location_id))
-        post_mock.assert_called_once()
+        well_lith_mock.assert_called_once()
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('ngwmn.views.r.post')
+    @mock.patch('ngwmn.services.ngwmn.r.post')
     @mock.patch('ngwmn.views.get_well_lithography')
     def test_failed_service_with_server_error(self, well_lith_mock, post_mock):
         well_lith_mock.return_value = fromstring(self.test_well_xml)
         post_resp = mock.Mock(r.Response)
-        post_resp.content = self.test_summary_xml
+        post_resp.content = self.test_summary_json
         post_resp.status_code = 500
+        post_resp.reason = 'server error'
         post_mock.return_value = post_resp
 
         response = self.app_client.get('/well-location/{}/{}/'.format(self.test_agency_cd, self.test_location_id))

--- a/server/ngwmn/views.py
+++ b/server/ngwmn/views.py
@@ -2,18 +2,12 @@
 NGWMN UI application views
 
 """
-from urllib.parse import urljoin
 
 from flask import abort, render_template
-import requests as r
 
-from . import app
-from .services.ngwmn import generate_bounding_box_values, get_well_lithography
-from .services.sifta import get_cooperators
-from .xml_utils import parse_xml
-
-
-SERVICE_ROOT = app.config.get('SERVICE_ROOT')
+from ngwmn import app
+from ngwmn.services.ngwmn import get_well_lithography, get_features
+from ngwmn.services.sifta import get_cooperators
 
 
 @app.route('/well-location/<agency_cd>/<location_id>/', methods=['GET'])
@@ -25,45 +19,17 @@ def well_page(agency_cd, location_id):
     :param location_id: the location's identifier
 
     """
-    root = get_well_lithography(SERVICE_ROOT, agency_cd, location_id)
-    cooperators = get_cooperators(location_id)
-    if root is not None and 'gml' in root.nsmap.keys():
-        geolocation_element = root.find('.//gml:Point/gml:pos', namespaces=root.nsmap)
-        geolocation = geolocation_element.text
-        latitude, longitude = geolocation.split(' ')
-        bbox = generate_bounding_box_values(latitude, longitude)
-        data = {
-            'SERVICE': 'WFS',
-            'VERSION': '1.0.0',
-            'srsName': 'EPSG:4326',
-            'outputFormat': 'GML2',
-            'typeName': 'ngwmn:VW_GWDP_GEOSERVER',
-            'CQL_FILTER': "((QW_SN_FLAG='1') OR (WL_SN_FLAG='1')) AND (BBOX(GEOM,{},{},{},{}))".format(*bbox)
-        }
-        params = {'request': 'GetFeature'}
-        target = urljoin(SERVICE_ROOT, 'ngwmn/geoserver/wfs')
-        resp = r.post(target, params=params, data=data)
-        if resp.status_code == 200:
-            summary = parse_xml(resp.content)
-            location_name = summary.find('.//ngwmn:SITE_NAME', namespaces=summary.nsmap).text
-            template = 'well_location.html'
-            context = {
-                'location_name': location_name,
-                'cooperators': cooperators
-            }
-            http_code = 200
-            # return render_template('well_location.html', location_name=location_name)
-        elif 400 <= resp.status_code < 500:
-            template = 'well_location.html'
-            http_code = 200
-            context = {'status_code': resp.status_code, 'reason': resp.reason}
-        elif 500 <= resp.status_code <= 511:
-            template = 'errors/500.html'
-            context = {}
-            http_code = 503
-        else:
-            template = 'errors/500.html'
-            context = {}
-            http_code = 500
-        return render_template(template, **context), http_code
-    return abort(404)
+    root = get_well_lithography(agency_cd, location_id)
+    if root is None or 'gml' not in root.nsmap.keys():
+        return abort(404)
+
+    geolocation_element = root.find('.//gml:Point/gml:pos', namespaces=root.nsmap)
+    geolocation = geolocation_element.text
+    latitude, longitude = geolocation.split(' ')
+    summary = get_features(latitude, longitude)
+
+    return render_template(
+        'well_location.html',
+        cooperators=get_cooperators(location_id),
+        location_name=summary['features'][0]['properties']['SITE_NAME']
+    ), 200

--- a/server/ngwmn/views.py
+++ b/server/ngwmn/views.py
@@ -31,5 +31,5 @@ def well_page(agency_cd, location_id):
     return render_template(
         'well_location.html',
         cooperators=get_cooperators(location_id),
-        location_name=summary['features'][0]['properties']['SITE_NAME']
+        feature=summary['features'][0]['properties']
     ), 200

--- a/server/ngwmn/views.py
+++ b/server/ngwmn/views.py
@@ -5,9 +5,9 @@ NGWMN UI application views
 
 from flask import abort, render_template
 
-from ngwmn import app
-from ngwmn.services.ngwmn import get_well_lithography, get_features
-from ngwmn.services.sifta import get_cooperators
+from . import app
+from .services.ngwmn import get_well_lithography, get_features
+from .services.sifta import get_cooperators
 
 
 @app.route('/well-location/<agency_cd>/<location_id>/', methods=['GET'])

--- a/server/ngwmn/views.py
+++ b/server/ngwmn/views.py
@@ -8,7 +8,7 @@ from flask import abort, render_template
 import requests as r
 
 from . import app
-from .fetch_utils import generate_bounding_box_values, get_well_lithography
+from .services.ngwmn import generate_bounding_box_values, get_well_lithography
 from .services.sifta import get_cooperators
 from .xml_utils import parse_xml
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

NGWMN-1674
-----------
Display a summary table duplicating the content in the existing UI.

This branch also moves the service calls into a `ngwmn.services` package, and introduces a `ServiceException` class to be raised when a service error needs to be propagated to the end-user. I hope this will simplify the logic in the views and make it easier to unit test the error behaviors.

![image](https://user-images.githubusercontent.com/136512/42596415-2eb17372-851b-11e8-954d-37a8e7a85b0c.png)


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
