### PR TITLE
Add well construction drawing over lithology chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added zoom behaviors to main chart
 - Added lithology chart
 - Added well log tables
+- Added well construction drawing (screens, casings)

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6608,8 +6608,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -75,6 +75,7 @@
     "autotrack": "^2.4.1",
     "d3": "^5.5.0",
     "fast-memoize": "^2.5.1",
+    "lodash": "^4.17.10",
     "raf-throttle": "^2.0.3",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",

--- a/assets/src/scripts/components/graph/index.spec.js
+++ b/assets/src/scripts/components/graph/index.spec.js
@@ -51,7 +51,7 @@ describe('graph component', () => {
         it('renders initial chart with appropriate content', () => {
             expect(div.classed('loading')).toBe(true);
             expect(div.classed('has-error')).toBe(false);
-            expect(div.selectAll('.chart').size()).toEqual(3);
+            expect(div.selectAll('.chart').size()).toEqual(4);
             expect(div.selectAll('.tooltip-text').size()).toEqual(0);
             expect(div.selectAll('circle.focus').size()).toBe(0);
             expect(div.selectAll('.line-segment').size()).toBe(0);

--- a/assets/src/scripts/components/graph/state/index.js
+++ b/assets/src/scripts/components/graph/state/index.js
@@ -4,11 +4,11 @@ import options from './options';
 
 export { getCursor, getCursorDatum, setCursor } from './cursor';
 export * from './layout';
-export * from './lithology';
 export * from './options';
 export { getActiveClasses, getChartPoints, getCurrentWaterLevels,
          getCurrentWaterLevelUnit, getExtentX, getLineSegments } from './points';
 export * from './scales';
+export * from './well-log';
 
 export default {
     ...cursor,

--- a/assets/src/scripts/components/graph/state/layout.js
+++ b/assets/src/scripts/components/graph/state/layout.js
@@ -163,6 +163,13 @@ export const getChartPosition = memoize(chartType => createSelector(
                     width: Math.max(width * 0.1, 0),
                     height: height * 0.8
                 };
+            case 'construction':
+                return {
+                    x: viewBox.right * 0.92,
+                    y: 0,
+                    width: Math.max(width * 0.06, 0),
+                    height: height * 0.8
+                };
             default:
                 return null;
         }

--- a/assets/src/scripts/components/graph/state/layout.spec.js
+++ b/assets/src/scripts/components/graph/state/layout.spec.js
@@ -43,6 +43,7 @@ describe('graph component layout state', () => {
         expect(getChartPosition('main')(store.getState())).not.toBe(null);
         expect(getChartPosition('brush')(store.getState())).not.toBe(null);
         expect(getChartPosition('lithology')(store.getState())).not.toBe(null);
+        expect(getChartPosition('construction')(store.getState())).not.toBe(null);
 
         // Works with specific container size
         store.dispatch(setContainerSize({width: 10, height: 20}));
@@ -50,6 +51,7 @@ describe('graph component layout state', () => {
         expect(getChartPosition('main')(store.getState())).not.toBe(null);
         expect(getChartPosition('brush')(store.getState())).not.toBe(null);
         expect(getChartPosition('lithology')(store.getState())).not.toBe(null);
+        expect(getChartPosition('construction')(store.getState())).not.toBe(null);
     });
 
     it('setAxisYBBox and getAxisYBBox works', () => {

--- a/assets/src/scripts/components/graph/state/points.js
+++ b/assets/src/scripts/components/graph/state/points.js
@@ -5,8 +5,8 @@ import { createSelector } from 'reselect';
 import { getWaterLevels } from 'ngwmn/services/state/index';
 
 import { getViewport } from './layout';
-import { getWellLogExtentY } from './lithology';
 import { getCurrentSiteID } from './options';
+import { getWellLogExtentY } from './well-log';
 
 
 // Lines will be split if the difference exceeds 6 months.

--- a/assets/src/scripts/components/graph/state/points.js
+++ b/assets/src/scripts/components/graph/state/points.js
@@ -90,18 +90,20 @@ export const getDomainY = memoize(chartType => createSelector(
             Math.min(...values),
             Math.max(...values)
         ];
-        const isPositive = domain[0] >= 0 && domain[1] >= 0;
 
-        // For the lithology and consturction charts, take into account the
+        // For the lithology and construction charts, take into account the
         // well log's extent and go to zero (or negative, for artesian wells).
         if (chartType === 'lithology' || chartType === 'construction') {
             domain = [
                 Math.min(0, wellLogExtentY[0], domain[0]),
                 Math.max(wellLogExtentY[1], domain[1])
             ];
+        }
+
+        const isPositive = domain[0] >= 0 && domain[1] >= 0;
 
         // Pad domains on both ends by PADDING_RATIO.
-        }  else {
+        if (chartType !== 'lithology' && chartType !== 'construction') {
             const padding = PADDING_RATIO * (domain[1] - domain[0]);
             domain = [
                 domain[0] - padding,

--- a/assets/src/scripts/components/graph/state/points.js
+++ b/assets/src/scripts/components/graph/state/points.js
@@ -92,17 +92,16 @@ export const getDomainY = memoize(chartType => createSelector(
         ];
         const isPositive = domain[0] >= 0 && domain[1] >= 0;
 
-        // For lithology charts, take into account the well log's extent and
-        // go to zero (or negative, for artesian wells).
-        if (chartType === 'lithology') {
+        // For the lithology and consturction charts, take into account the
+        // well log's extent and go to zero (or negative, for artesian wells).
+        if (chartType === 'lithology' || chartType === 'construction') {
             domain = [
                 Math.min(0, wellLogExtentY[0], domain[0]),
                 Math.max(wellLogExtentY[1], domain[1])
             ];
-        }
 
         // Pad domains on both ends by PADDING_RATIO.
-        if (chartType !== 'lithology') {
+        }  else {
             const padding = PADDING_RATIO * (domain[1] - domain[0]);
             domain = [
                 domain[0] - padding,

--- a/assets/src/scripts/components/graph/state/well-log.js
+++ b/assets/src/scripts/components/graph/state/well-log.js
@@ -2,8 +2,9 @@ import memoize from 'fast-memoize';
 import { createSelector } from 'reselect';
 
 import { getWellLogs } from 'ngwmn/services/state/index';
+import { getChartPosition } from './layout';
 import { getCurrentSiteID } from './options';
-import { getChartPosition, getScaleY } from '../state';
+import { getScaleY } from './scales';
 
 
 /**

--- a/assets/src/scripts/components/graph/state/well-log.js
+++ b/assets/src/scripts/components/graph/state/well-log.js
@@ -111,9 +111,9 @@ export const getWellWaterLevel = memoize(chartType => createSelector(
         const top = yScale(cursorDatum.value);
         const bottom = yScale(extentY[1]);
         return {
-            x: xScale.range()[0] + 35,
+            x: xScale.range()[0] + 5,
             y: top,
-            width: Math.max(0, chartPos.width - 70),
+            width: Math.max(0, chartPos.width - 10),
             height: Math.max(bottom - top, 0)
         };
     }
@@ -134,9 +134,9 @@ export const getConstructionElements = memoize(chartType => createSelector(
             const loc = element.position.coordinates;
             return {
                 type: element.type,
-                x: xScale.range()[0] + 30,
+                x: xScale.range()[0],
                 y: yScale(loc.start),
-                width: Math.max(0, chartPos.width - 60),
+                width: Math.max(0, chartPos.width),
                 height: Math.max(yScale(loc.end - loc.start), 0),
                 element
             };

--- a/assets/src/scripts/components/graph/state/well-log.js
+++ b/assets/src/scripts/components/graph/state/well-log.js
@@ -1,4 +1,3 @@
-import { scaleLinear } from 'd3-scale';
 import memoize from 'fast-memoize';
 import { createSelector } from 'reselect';
 
@@ -76,63 +75,20 @@ export const getLithology = memoize(chartType => createSelector(
     }
 ));
 
-const getDrawableCasings = createSelector(
+const getDrawableElements = createSelector(
     getCurrentWellLog,
     (wellLog) => {
-        return (wellLog.casings || [])
-            .filter(casing => casing.position && casing.position.coordinates);
-    }
-);
-
-const getDrawableScreens = createSelector(
-    getCurrentWellLog,
-    (wellLog) => {
-        return (wellLog.screens || [])
-            .filter(screen => screen.position && screen.position.coordinates);
-    }
-);
-
-const getScreenExtentY = createSelector(
-    getDrawableScreens,
-    (screens) => {
-        return [
-            Math.min(...screens.map(screen => screen.position.coordinates.start)),
-            Math.max(...screens.map(screen => screen.position.coordinates.end))
-        ];
-    }
-);
-
-const getCasingExtentY = createSelector(
-    getDrawableCasings,
-    (casings) => {
-        return [
-            Math.min(...casings.map(casing => casing.position.coordinates.start)),
-            Math.max(...casings.map(casing => casing.position.coordinates.end))
-        ];
-    }
-);
-
-const getWellDiameterExtent = createSelector(
-    getDrawableScreens,
-    getDrawableCasings,
-    (screens, casings) => {
-        const values = [...screens, ...casings]
-            .map(part => part.diameter.value)
-            .filter(part => part !== null);
-        return [
-            Math.min(...values),
-            Math.max(...values)
-        ];
+        return (wellLog.construction || [])
+            .filter(element => element.position && element.position.coordinates);
     }
 );
 
 const getWellExtentY = createSelector(
-    getScreenExtentY,
-    getCasingExtentY,
-    (screenExtent, casingExtent) => {
+    getDrawableElements,
+    (elements) => {
         return [
-            Math.min(screenExtent[0], casingExtent[0]),
-            Math.max(screenExtent[1], casingExtent[1])
+            Math.min(...elements.map(elem => elem.position.coordinates.start)),
+            Math.max(...elements.map(elem => elem.position.coordinates.end))
         ];
     }
 );
@@ -164,53 +120,43 @@ export const getWellWaterLevel = memoize(chartType => createSelector(
 ));
 
 /**
- * Returns the construction casing entries for the current site.
+ * Returns the construction elements for the current site.
  * @param  {Object} state       Redux state
- * @return {Array}              Array of casings
+ * @return {Array}              Array of elements
  */
-export const getCasings = memoize(chartType => createSelector(
-    getDrawableCasings,
+export const getConstructionElements = memoize(chartType => createSelector(
+    getDrawableElements,
     getChartPosition(chartType),
     getScaleX(chartType),
     getScaleY(chartType),
-    (casings, chartPos, xScale, yScale) => {
-        return casings.map(casing => {
-            const loc = casing.position.coordinates;
+    (elements, chartPos, xScale, yScale) => {
+        return elements.map(element => {
+            const loc = element.position.coordinates;
             return {
+                type: element.type,
                 x: xScale.range()[0] + 30,
                 y: yScale(loc.start),
                 width: Math.max(0, chartPos.width - 60),
                 height: Math.max(yScale(loc.end - loc.start), 0),
-                casing
+                element
             };
         });
     }
 ));
 
-/**
- * Returns the construction screen entries for the current site.
- * @param  {Object} state       Redux state
- * @return {Array}              Array of screens
- */
-export const getScreens = memoize(chartType => createSelector(
-    getDrawableScreens,
-    getChartPosition(chartType),
-    getScaleX(chartType),
-    getScaleY(chartType),
-    (screens, chartPos, xScale, yScale) => {
-        return screens.map(screen => {
-            const loc = screen.position.coordinates;
-
-            return {
-                x: xScale.range()[0] + 35,
-                y: yScale(loc.start),
-                width: Math.max(0, chartPos.width - 70),
-                height: Math.max(yScale(loc.end - loc.start), 0),
-                screen
-            };
-        });
+/*
+const getWellDiameterExtent = createSelector(
+    getDrawableElements,
+    (elements) => {
+        const values = elements
+            .map(part => part.diameter.value)
+            .filter(part => part !== null);
+        return [
+            Math.min(...values),
+            Math.max(...values)
+        ];
     }
-));
+);
 
 export const getRadiusScale = memoize(chartType => createSelector(
     getWellDiameterExtent,
@@ -226,12 +172,11 @@ export const getRadiusScale = memoize(chartType => createSelector(
 ));
 
 export const getConstruction = memoize(chartType => createSelector(
-    getDrawableCasings,
-    getDrawableScreens,
+    getDrawableElements,
     getRadiusScale,
     getScaleY(chartType),
-    (casings, screens, xScale, yScale) => {
-        [...casings, ...screens].map(part => {
+    (elements, xScale, yScale) => {
+        elements.map(part => {
             return {
                 x1: 0,
                 y1: yScale(part.position.coordinates.start),
@@ -241,3 +186,4 @@ export const getConstruction = memoize(chartType => createSelector(
         });
     }
 ));
+*/

--- a/assets/src/scripts/components/graph/state/well-log.js
+++ b/assets/src/scripts/components/graph/state/well-log.js
@@ -23,7 +23,7 @@ export const getCurrentWellLog = createSelector(
 /**
  * Returns the well log entries for the current site.
  * @param  {Object} state       Redux state
- * @return {Object}             Well log object
+ * @return {Array}              List of well log entries
  */
 export const getWellLogEntries = createSelector(
     getCurrentWellLog,
@@ -35,7 +35,7 @@ export const getWellLogEntries = createSelector(
 /**
  * Returns the depth extent for the current well log.
  * @param  {Object} state       Redux state
- * @return {Object}             Well log object
+ * @return {Array}              y-extent [min, max]
  */
 export const getWellLogExtentY = createSelector(
     getWellLogEntries,
@@ -73,3 +73,22 @@ export const getLithology = memoize(chartType => createSelector(
         });
     }
 ));
+
+/**
+ * Returns the construction casing entries for the current site.
+ * @param  {Object} state       Redux state
+ * @return {Array}              List of casings
+ */
+export const getCasings = createSelector(
+    getCurrentWellLog,
+    (wellLog) => {
+        return wellLog.casings || [];
+    }
+);
+
+export const getScreens = createSelector(
+    getCurrentWellLog,
+    (wellLog) => {
+        return wellLog.screens || [];
+    }
+);

--- a/assets/src/scripts/components/graph/state/well-log.js
+++ b/assets/src/scripts/components/graph/state/well-log.js
@@ -129,9 +129,9 @@ export const getWellWaterLevel = memoize(chartType => createSelector(
         const bottom = yScale(extentY[1]);
         const xRange = xScale.range();
         return {
-            x: xRange[0] + 5,
+            x: xRange[0],
             y: top,
-            width: Math.max(0, xRange[1] - xRange[0] - 10),
+            width: xRange[1],
             height: Math.max(bottom - top, 0)
         };
     }

--- a/assets/src/scripts/components/graph/state/well-log.js
+++ b/assets/src/scripts/components/graph/state/well-log.js
@@ -2,9 +2,10 @@ import memoize from 'fast-memoize';
 import { createSelector } from 'reselect';
 
 import { getWellLogs } from 'ngwmn/services/state/index';
+import { getCursorDatum } from './cursor';
 import { getChartPosition } from './layout';
 import { getCurrentSiteID } from './options';
-import { getScaleY } from './scales';
+import { getScaleX, getScaleY } from './scales';
 
 
 /**
@@ -44,8 +45,8 @@ export const getWellLogExtentY = createSelector(
             return [0, 0];
         }
         return [
-            Math.min(...wellLogEntries.map(entry => parseFloat(entry.shape.coordinates.start))),
-            Math.max(...wellLogEntries.map(entry => parseFloat(entry.shape.coordinates.end)))
+            Math.min(...wellLogEntries.map(entry => entry.shape.coordinates.start)),
+            Math.max(...wellLogEntries.map(entry => entry.shape.coordinates.end))
         ];
     }
 );
@@ -61,8 +62,8 @@ export const getLithology = memoize(chartType => createSelector(
     getScaleY(chartType),
     (wellLogEntries, layout, yScale) => {
         return wellLogEntries.map(entry => {
-            const top = yScale(parseFloat(entry.shape.coordinates.start)) || 0;
-            const bottom = yScale(parseFloat(entry.shape.coordinates.end)) || 0;
+            const top = yScale(entry.shape.coordinates.start) || 0;
+            const bottom = yScale(entry.shape.coordinates.end) || 0;
             return {
                 x: layout.x,
                 y: top,
@@ -74,21 +75,123 @@ export const getLithology = memoize(chartType => createSelector(
     }
 ));
 
-/**
- * Returns the construction casing entries for the current site.
- * @param  {Object} state       Redux state
- * @return {Array}              List of casings
- */
-export const getCasings = createSelector(
+const getDrawableCasings = createSelector(
     getCurrentWellLog,
     (wellLog) => {
-        return wellLog.casings || [];
+        return (wellLog.casings || [])
+            .filter(casing => casing.position && casing.position.coordinates);
     }
 );
 
-export const getScreens = createSelector(
+/**
+ * Returns the construction casing entries for the current site.
+ * @param  {Object} state       Redux state
+ * @return {Array}              Array of casings
+ */
+export const getCasings = memoize(chartType => createSelector(
+    getDrawableCasings,
+    getChartPosition(chartType),
+    getScaleX(chartType),
+    getScaleY(chartType),
+    (casings, chartPos, xScale, yScale) => {
+        return casings.map(casing => {
+            const loc = casing.position.coordinates;
+            return {
+                x: xScale.range()[0] + 30,
+                y: yScale(loc.start),
+                width: Math.max(0, chartPos.width - 60),
+                height: Math.max(yScale(loc.end - loc.start), 0),
+                casing
+            };
+        });
+    }
+));
+
+const getDrawableScreens = createSelector(
     getCurrentWellLog,
     (wellLog) => {
-        return wellLog.screens || [];
+        return (wellLog.screens || [])
+            .filter(screen => screen.position && screen.position.coordinates);
     }
 );
+
+/**
+ * Returns the construction screen entries for the current site.
+ * @param  {Object} state       Redux state
+ * @return {Array}              Array of screens
+ */
+export const getScreens = memoize(chartType => createSelector(
+    getDrawableScreens,
+    getChartPosition(chartType),
+    getScaleX(chartType),
+    getScaleY(chartType),
+    (screens, chartPos, xScale, yScale) => {
+        return screens.map(screen => {
+            const loc = screen.position.coordinates;
+            return {
+                x: xScale.range()[0] + 35,
+                y: yScale(loc.start),
+                width: Math.max(0, chartPos.width - 70),
+                height: Math.max(yScale(loc.end - loc.start), 0),
+                screen
+            };
+        });
+    }
+));
+
+const getScreenExtentY = createSelector(
+    getDrawableScreens,
+    (screens) => {
+        return [
+            Math.min(...screens.map(screen => screen.position.coordinates.start)),
+            Math.max(...screens.map(screen => screen.position.coordinates.end))
+        ];
+    }
+);
+
+const getCasingExtentY = createSelector(
+    getDrawableCasings,
+    (casings) => {
+        return [
+            Math.min(...casings.map(casing => casing.position.coordinates.start)),
+            Math.max(...casings.map(casing => casing.position.coordinates.end))
+        ];
+    }
+);
+
+const getWellExtentY = createSelector(
+    getScreenExtentY,
+    getCasingExtentY,
+    (screenExtent, casingExtent) => {
+        return [
+            Math.min(screenExtent[0], casingExtent[0]),
+            Math.max(screenExtent[1], casingExtent[1])
+        ];
+    }
+);
+
+/**
+ * Returns extent of the water level for the cursor location.
+ * @param  {Object} state       Redux state
+ * @return {Array}              Water level rectangle
+ */
+export const getWellWaterLevel = memoize(chartType => createSelector(
+    getChartPosition(chartType),
+    getScaleX(chartType),
+    getScaleY(chartType),
+    getCursorDatum,
+    getWellExtentY,
+    (chartPos, xScale, yScale, cursorDatum, extentY) => {
+        if (!cursorDatum) {
+            return null;
+        }
+        const top = yScale(cursorDatum.value);
+        const bottom = yScale(extentY[1]);
+        return {
+            x: xScale.range()[0] + 35,
+            y: top,
+            width: Math.max(0, chartPos.width - 70),
+            height: Math.max(bottom - top, 0)
+        };
+    }
+));

--- a/assets/src/scripts/components/graph/state/well-log.spec.js
+++ b/assets/src/scripts/components/graph/state/well-log.spec.js
@@ -2,8 +2,8 @@ import { scaleLinear } from 'd3-scale';
 
 import getMockStore from 'ngwmn/store.mock';
 import {
-    getCasings, getCurrentWellLog, getLithology, getScreens, getWellLogEntries,
-    getWellLogExtentY
+    getCurrentWellLog, getConstructionElements, getLithology,
+    getWellLogEntries, getWellLogExtentY
 } from './well-log';
 
 
@@ -138,7 +138,7 @@ describe('graph component well log state', () => {
         });
     });
 
-    describe('getCasings', () => {
+    describe('getConstructionElements', () => {
         const casings = [{
             position: {
                 coordinates: {
@@ -149,42 +149,17 @@ describe('graph component well log state', () => {
         }];
 
         it('works', () => {
-            expect(getCasings('main').resultFunc(casings, {
+            expect(getConstructionElements('main').resultFunc(casings, {
                 width: 10
             }, scaleLinear(), scaleLinear()).length).toEqual(casings.length);
         });
 
         it('works with no casings', () => {
-            expect(getCasings('main').resultFunc([])).toEqual([]);
+            expect(getConstructionElements('main').resultFunc([])).toEqual([]);
         });
 
         it('works with mock state', () => {
-            expect(getCasings('main')(getMockStore().getState())).not.toBe(null);
-        });
-    });
-
-    describe('getScreens', () => {
-        const screens = [{
-            position: {
-                coordinates: {
-                    start: 10,
-                    end: 100
-                }
-            }
-        }];
-
-        it('works', () => {
-            expect(getScreens('main').resultFunc(screens, {
-                width: 10
-            }, scaleLinear(), scaleLinear()).length).toEqual(screens.length);
-        });
-
-        it('works with no screens', () => {
-            expect(getScreens('main').resultFunc([])).toEqual([]);
-        });
-
-        it('works with mock state', () => {
-            expect(getScreens('main')(getMockStore().getState())).not.toBe(null);
+            expect(getConstructionElements('main')(getMockStore().getState())).not.toBe(null);
         });
     });
 });

--- a/assets/src/scripts/components/graph/state/well-log.spec.js
+++ b/assets/src/scripts/components/graph/state/well-log.spec.js
@@ -3,7 +3,7 @@ import { scaleLinear } from 'd3-scale';
 import getMockStore from 'ngwmn/store.mock';
 import {
     getCurrentWellLog, getConstructionElements, getLithology,
-    getWellLogEntries, getWellLogExtentY
+    getWellLogEntries, getWellLogExtentY, getWellWaterLevel
 } from './well-log';
 
 
@@ -139,27 +139,120 @@ describe('graph component well log state', () => {
     });
 
     describe('getConstructionElements', () => {
-        const casings = [{
+        const elements = [{
+            type: 'screen',
+            position: {
+                coordinates: {
+                    start: 100,
+                    end: 200
+                }
+            },
+            diameter: {
+                value: 10
+            }
+        }, {
+            type: 'screen',
             position: {
                 coordinates: {
                     start: 10,
                     end: 100
                 }
+            },
+            diameter: {
+                value: 12
+            }
+        }, {
+            type: 'screen',
+            position: {
+                coordinates: {
+                    start: 10,
+                    end: 100
+                }
+            },
+            diameter: {
+                value: 10
             }
         }];
 
-        it('works', () => {
-            expect(getConstructionElements('main').resultFunc(casings, {
-                width: 10
-            }, scaleLinear(), scaleLinear()).length).toEqual(casings.length);
+        it('returns correct data properly sorted', () => {
+            expect(getConstructionElements('main').resultFunc(
+                elements,
+                scaleLinear(),
+                scaleLinear()
+            )).toEqual([{
+                type: 'screen',
+                radius: 6,
+                thickness: 0.5,
+                left: {
+                    x: -6,
+                    y1: 10,
+                    y2: 100
+                },
+                right: {
+                    x: 6,
+                    y1: 10,
+                    y2: 100
+                }
+            }, {
+                type: 'screen',
+                radius: 5,
+                thickness: 0.5,
+                left: {
+                    x: -5,
+                    y1: 10,
+                    y2: 100
+                },
+                right: {
+                    x: 5,
+                    y1: 10,
+                    y2: 100
+                }
+            }, {
+                type: 'screen',
+                radius: 5,
+                thickness: 0.5,
+                left: {
+                    x: -5,
+                    y1: 100,
+                    y2: 200
+                },
+                right: {
+                    x: 5,
+                    y1: 100,
+                    y2: 200
+                }
+            }]);
         });
 
-        it('works with no casings', () => {
+        it('works with no elements', () => {
             expect(getConstructionElements('main').resultFunc([])).toEqual([]);
         });
 
         it('works with mock state', () => {
-            expect(getConstructionElements('main')(getMockStore().getState())).not.toBe(null);
+            expect(getConstructionElements('main')(
+                getMockStore().getState())
+            ).not.toBe(null);
+        });
+    });
+
+    describe('getWellWaterLevel', () => {
+        it('works', () => {
+            expect(getWellWaterLevel('main').resultFunc(
+                scaleLinear().range([0, 100]).domain([0, 100]),
+                scaleLinear().range([0, 100]).domain([new Date('2009-10-10'),
+                                                      new Date('2011-10-10')]),
+                {value: new Date('2010-10-10')},
+                [0, 100]
+            )).toEqual({
+                x: 5,
+                y: 50,
+                width: 90,
+                height: 0
+            });
+        });
+
+        it('works with mock state', () => {
+            expect(getWellWaterLevel('main')(getMockStore().getState())).not.toBe(null);
         });
     });
 });

--- a/assets/src/scripts/components/graph/state/well-log.spec.js
+++ b/assets/src/scripts/components/graph/state/well-log.spec.js
@@ -139,40 +139,52 @@ describe('graph component well log state', () => {
     });
 
     describe('getCasings', () => {
-        const casings = [1, 2, 3];
-        const wellLog = {
-            casings
-        };
+        const casings = [{
+            position: {
+                coordinates: {
+                    start: 10,
+                    end: 100
+                }
+            }
+        }];
 
         it('works', () => {
-            expect(getCasings.resultFunc(wellLog)).toEqual(casings);
+            expect(getCasings('main').resultFunc(casings, {
+                width: 10
+            }, scaleLinear(), scaleLinear()).length).toEqual(casings.length);
         });
 
-        it('works with empty log', () => {
-            expect(getCasings.resultFunc({})).toEqual([]);
+        it('works with no casings', () => {
+            expect(getCasings('main').resultFunc([])).toEqual([]);
         });
 
         it('works with mock state', () => {
-            expect(getCasings(getMockStore().getState())).not.toBe(null);
+            expect(getCasings('main')(getMockStore().getState())).not.toBe(null);
         });
     });
 
     describe('getScreens', () => {
-        const screens = [1, 2, 3];
-        const wellLog = {
-            screens
-        };
+        const screens = [{
+            position: {
+                coordinates: {
+                    start: 10,
+                    end: 100
+                }
+            }
+        }];
 
         it('works', () => {
-            expect(getScreens.resultFunc(wellLog)).toEqual(screens);
+            expect(getScreens('main').resultFunc(screens, {
+                width: 10
+            }, scaleLinear(), scaleLinear()).length).toEqual(screens.length);
         });
 
-        it('works with empty log', () => {
-            expect(getScreens.resultFunc({})).toEqual([]);
+        it('works with no screens', () => {
+            expect(getScreens('main').resultFunc([])).toEqual([]);
         });
 
         it('works with mock state', () => {
-            expect(getScreens(getMockStore().getState())).not.toBe(null);
+            expect(getScreens('main')(getMockStore().getState())).not.toBe(null);
         });
     });
 });

--- a/assets/src/scripts/components/graph/state/well-log.spec.js
+++ b/assets/src/scripts/components/graph/state/well-log.spec.js
@@ -2,11 +2,12 @@ import { scaleLinear } from 'd3-scale';
 
 import getMockStore from 'ngwmn/store.mock';
 import {
-    getCurrentWellLog, getLithology, getWellLogEntries, getWellLogExtentY
+    getCasings, getCurrentWellLog, getLithology, getScreens, getWellLogEntries,
+    getWellLogExtentY
 } from './well-log';
 
 
-describe('graph component lithology state', () => {
+describe('graph component well log state', () => {
     describe('getCurrentWellLog', () => {
         const wellLogs = {
             'log1': 'well log 1'
@@ -134,6 +135,44 @@ describe('graph component lithology state', () => {
 
         it('works with mock state', () => {
             expect(getLithology('main')(getMockStore().getState())).not.toBe(null);
+        });
+    });
+
+    describe('getCasings', () => {
+        const casings = [1, 2, 3];
+        const wellLog = {
+            casings
+        };
+
+        it('works', () => {
+            expect(getCasings.resultFunc(wellLog)).toEqual(casings);
+        });
+
+        it('works with empty log', () => {
+            expect(getCasings.resultFunc({})).toEqual([]);
+        });
+
+        it('works with mock state', () => {
+            expect(getCasings(getMockStore().getState())).not.toBe(null);
+        });
+    });
+
+    describe('getScreens', () => {
+        const screens = [1, 2, 3];
+        const wellLog = {
+            screens
+        };
+
+        it('works', () => {
+            expect(getScreens.resultFunc(wellLog)).toEqual(screens);
+        });
+
+        it('works with empty log', () => {
+            expect(getScreens.resultFunc({})).toEqual([]);
+        });
+
+        it('works with mock state', () => {
+            expect(getScreens(getMockStore().getState())).not.toBe(null);
         });
     });
 });

--- a/assets/src/scripts/components/graph/state/well-log.spec.js
+++ b/assets/src/scripts/components/graph/state/well-log.spec.js
@@ -2,8 +2,9 @@ import { scaleLinear } from 'd3-scale';
 
 import getMockStore from 'ngwmn/store.mock';
 import {
-    getCurrentWellLog, getConstructionElements, getLithology,
-    getWellLogEntries, getWellLogExtentY, getWellWaterLevel
+    getCurrentWellLog, getConstructionElements, getConstructionExtentY,
+    getLithology, getWellLogEntries, getWellLogEntriesExtentY,
+    getWellLogExtentY, getWellWaterLevel
 } from './well-log';
 
 
@@ -45,7 +46,7 @@ describe('graph component well log state', () => {
         });
     });
 
-    describe('getWellLogExtentY', () => {
+    describe('getWellLogEntriesExtentY', () => {
         const logEntries = [{
             shape: {
                 coordinates: {
@@ -63,15 +64,51 @@ describe('graph component well log state', () => {
         }];
 
         it('works', () => {
-            expect(getWellLogExtentY.resultFunc(logEntries)).toEqual([1, 3]);
+            expect(getWellLogEntriesExtentY.resultFunc(logEntries)).toEqual([1, 3]);
         });
 
         it('works with empty log', () => {
-            expect(getWellLogExtentY.resultFunc([])).toEqual([0, 0]);
+            expect(getWellLogEntriesExtentY.resultFunc([])).toEqual([0, 0]);
         });
 
         it('works with mock state', () => {
-            expect(getWellLogEntries(getMockStore().getState())).not.toBe(null);
+            expect(getWellLogEntriesExtentY(getMockStore().getState())).not.toBe(null);
+        });
+    });
+
+    describe('getWellLogExtentY', () => {
+        it('works', () => {
+            expect(getWellLogExtentY.resultFunc([0, 3], [1, 4])).toEqual([0, 4]);
+        });
+
+        it('works with mock state', () => {
+            expect(getWellLogExtentY(getMockStore().getState())).not.toBe(null);
+        });
+    });
+
+    describe('getConstructionExtentY', () => {
+        const elements = [{
+            position: {
+                coordinates: {
+                    start: '1',
+                    end: '2'
+                }
+            }
+        }, {
+            position: {
+                coordinates: {
+                    start: '2',
+                    end: '3'
+                }
+            }
+        }];
+
+        it('works', () => {
+            expect(getConstructionExtentY.resultFunc(elements)).toEqual([1, 3]);
+        });
+
+        it('works with mock state', () => {
+            expect(getConstructionExtentY(getMockStore().getState())).not.toBe(null);
         });
     });
 
@@ -148,7 +185,8 @@ describe('graph component well log state', () => {
                 }
             },
             diameter: {
-                value: 10
+                value: 10,
+                unit: 'in'
             }
         }, {
             type: 'screen',
@@ -159,7 +197,8 @@ describe('graph component well log state', () => {
                 }
             },
             diameter: {
-                value: 12
+                value: 12,
+                unit: 'in'
             }
         }, {
             type: 'screen',
@@ -170,7 +209,8 @@ describe('graph component well log state', () => {
                 }
             },
             diameter: {
-                value: 10
+                value: 10,
+                unit: 'in'
             }
         }];
 
@@ -181,7 +221,23 @@ describe('graph component well log state', () => {
                 scaleLinear()
             )).toEqual([{
                 type: 'screen',
+                radius: 5,
+                title: 'Screen, 10 in diameter, 100 - 200 undefined depth',
+                thickness: 0.5,
+                left: {
+                    x: -5,
+                    y1: 100,
+                    y2: 200
+                },
+                right: {
+                    x: 5,
+                    y1: 100,
+                    y2: 200
+                }
+            }, {
+                type: 'screen',
                 radius: 6,
+                title: 'Screen, 12 in diameter, 10 - 100 undefined depth',
                 thickness: 0.5,
                 left: {
                     x: -6,
@@ -196,6 +252,7 @@ describe('graph component well log state', () => {
             }, {
                 type: 'screen',
                 radius: 5,
+                title: 'Screen, 10 in diameter, 10 - 100 undefined depth',
                 thickness: 0.5,
                 left: {
                     x: -5,
@@ -206,20 +263,6 @@ describe('graph component well log state', () => {
                     x: 5,
                     y1: 10,
                     y2: 100
-                }
-            }, {
-                type: 'screen',
-                radius: 5,
-                thickness: 0.5,
-                left: {
-                    x: -5,
-                    y1: 100,
-                    y2: 200
-                },
-                right: {
-                    x: 5,
-                    y1: 100,
-                    y2: 200
                 }
             }]);
         });

--- a/assets/src/scripts/components/graph/state/well-log.spec.js
+++ b/assets/src/scripts/components/graph/state/well-log.spec.js
@@ -287,9 +287,9 @@ describe('graph component well log state', () => {
                 {value: new Date('2010-10-10')},
                 [0, 100]
             )).toEqual({
-                x: 5,
+                x: 0,
                 y: 50,
-                width: 90,
+                width: 100,
                 height: 0
             });
         });

--- a/assets/src/scripts/components/graph/state/well-log.spec.js
+++ b/assets/src/scripts/components/graph/state/well-log.spec.js
@@ -1,11 +1,9 @@
 import { scaleLinear } from 'd3-scale';
 
 import getMockStore from 'ngwmn/store.mock';
-
 import {
     getCurrentWellLog, getLithology, getWellLogEntries, getWellLogExtentY
-} from './lithology';
-
+} from './well-log';
 
 
 describe('graph component lithology state', () => {

--- a/assets/src/scripts/components/graph/view/construction.js
+++ b/assets/src/scripts/components/graph/view/construction.js
@@ -53,6 +53,15 @@ const drawWaterLevel = function (elem, elements, cursorWaterLevel) {
             });
     container
         .append('rect')
+            .attr('id', 'well-interior')
+            .attr('clip-path', 'url(#water-level-path)')
+            .attr('x', cursorWaterLevel.x)
+            .attr('y', 0)
+            .attr('width', cursorWaterLevel.width)
+            .attr('height', cursorWaterLevel.height)
+            .attr('fill', 'white');
+    container
+        .append('rect')
             .attr('id', 'water-level')
             .attr('clip-path', 'url(#water-level-path)')
             .attr('x', cursorWaterLevel.x)

--- a/assets/src/scripts/components/graph/view/construction.js
+++ b/assets/src/scripts/components/graph/view/construction.js
@@ -1,36 +1,26 @@
-const drawCasing = function (elem, casing, index) {
+const drawElement = function (elem, element, index) {
     elem.append('g')
-        .attr('id', `casing-${index}`)
-        .classed('casing', true)
+        .attr('id', `${element.type}-${index}`)
+        .classed(element.type, true)
         .call(elem => {
             elem.append('rect')
-                .attr('x', casing.x)
-                .attr('y', casing.y)
-                .attr('width', casing.width)
-                .attr('height', casing.height);
+                .attr('x', element.left.x)
+                .attr('y', element.left.y1)
+                .attr('width', element.right.x - element.left.x)
+                .attr('height', element.right.y2 - element.right.y1);
             elem.append('line')
-                .attr('x1', casing.x)
-                .attr('y1', casing.y)
-                .attr('x2', casing.x)
-                .attr('y2', casing.y + casing.height);
+                .attr('x1', element.left.x)
+                .attr('y1', element.left.y1)
+                .attr('x2', element.left.x)
+                .attr('y2', element.left.y2)
+                .attr('stroke-width', element.thickness);
             elem.append('line')
-                .attr('x1', casing.x + casing.width)
-                .attr('y1', casing.y)
-                .attr('x2', casing.x + casing.width)
-                .attr('y2', casing.y + casing.height);
+                .attr('x1', element.right.x)
+                .attr('y1', element.right.y1)
+                .attr('x2', element.right.x)
+                .attr('y2', element.right.y2)
+                .attr('stroke-width', element.thickness);
         });
-};
-
-const drawScreen = function (elem, screen, index) {
-    elem.append('rect')
-        .attr('id', `screen-${index}`)
-        .attr('x', screen.x)
-        .attr('y', screen.y)
-        .attr('width', screen.width)
-        .attr('height', screen.height)
-        .attr('fill', 'url(#screen-pattern)')
-        .attr('rx', 5)
-        .attr('ry', 5);
 };
 
 const drawWaterLevel = function (elem, cursorWaterLevel) {
@@ -52,18 +42,8 @@ const drawWaterLevel = function (elem, cursorWaterLevel) {
 const drawPatterns = function (elem) {
     elem.append('defs')
         .call(defs => {
-            defs.append('mask')
-                .attr('id', 'screen-mask')
-                .attr('maskUnits', 'userSpaceOnUse')
-                .append('rect')
-                    .attr('x', '0')
-                    .attr('y', '0')
-                    .attr('width', '100%')
-                    .attr('height', '100%')
-                    .attr('fill', '#0000ff');
-
             defs.append('pattern')
-                .attr('id', 'screen-pattern')
+                .attr('id', 'screen-0')
                 .attr('width', '3')
                 .attr('height', '3')
                 .attr('patternUnits', 'userSpaceOnUse')
@@ -71,8 +51,19 @@ const drawPatterns = function (elem) {
                 .append('rect')
                     .attr('width', '1')
                     .attr('height', '3')
-                    .attr('transform', 'translate(0, 0)')
-                    .attr('mask', 'url(#screen-mask)');
+                    .attr('fill', 'gray')
+                    .attr('transform', 'translate(0, 0)');
+            defs.append('pattern')
+                .attr('id', 'screen-1')
+                .attr('width', '3')
+                .attr('height', '3')
+                .attr('patternUnits', 'userSpaceOnUse')
+                .attr('patternTransform', 'rotate(-45)')
+                .append('rect')
+                    .attr('width', '1')
+                    .attr('height', '3')
+                    .attr('fill', 'gray')
+                    .attr('transform', 'translate(0, 0)');
         });
 };
 
@@ -88,15 +79,11 @@ export default function (elem, {elements, cursorWaterLevel}, container) {
 
     // Draw each construction element
     elements.forEach((element, index) => {
-        if (element.type === 'casing') {
-            drawCasing(container, element, index);
-        } else {
-            drawScreen(container, element, index);
-        }
+        drawElement(container, element, index);
     });
 
     // Draw the current cursor water level inside the well chamber
-    drawWaterLevel(container, cursorWaterLevel);
+    //drawWaterLevel(container, cursorWaterLevel);
 
     return container;
 }

--- a/assets/src/scripts/components/graph/view/construction.js
+++ b/assets/src/scripts/components/graph/view/construction.js
@@ -21,29 +21,6 @@ const drawCasing = function (elem, casing, index) {
         });
 };
 
-const drawCasing2 = function (elem, casing, index) {
-    elem.append('g')
-        .attr('id', `casing-${index}`)
-        .classed('casing', true)
-        .call(elem => {
-            elem.append('rect')
-                .attr('x', casing.x)
-                .attr('y', casing.y)
-                .attr('width', casing.width)
-                .attr('height', casing.height);
-            elem.append('line')
-                .attr('x1', casing.x)
-                .attr('y1', casing.y)
-                .attr('x2', casing.x)
-                .attr('y2', casing.y + casing.height);
-            elem.append('line')
-                .attr('x1', casing.x + casing.width)
-                .attr('y1', casing.y)
-                .attr('x2', casing.x + casing.width)
-                .attr('y2', casing.y + casing.height);
-        });
-};
-
 const drawScreen = function (elem, screen, index) {
     elem.append('rect')
         .attr('id', `screen-${index}`)
@@ -68,7 +45,8 @@ const drawWaterLevel = function (elem, cursorWaterLevel) {
         .attr('y', cursorWaterLevel.y)
         .attr('width', cursorWaterLevel.width)
         .attr('height', cursorWaterLevel.height)
-        .attr('fill', 'lightblue');
+        .attr('fill', 'lightblue')
+        .attr('fill-opacity', '0.85');
 };
 
 const drawPatterns = function (elem) {
@@ -98,7 +76,7 @@ const drawPatterns = function (elem) {
         });
 };
 
-export default function (elem, {casings, screens, cursorWaterLevel}, container) {
+export default function (elem, {elements, cursorWaterLevel}, container) {
     // Get/create container for construction elements
     container = container || elem
         .call(drawPatterns)
@@ -108,14 +86,17 @@ export default function (elem, {casings, screens, cursorWaterLevel}, container) 
     // Remove any previously drawn children
     container.selectAll('*').remove();
 
-    // Draw each casing
-    casings.forEach((casing, index) => drawCasing2(container, casing, index));
+    // Draw each construction element
+    elements.forEach((element, index) => {
+        if (element.type === 'casing') {
+            drawCasing(container, element, index);
+        } else {
+            drawScreen(container, element, index);
+        }
+    });
 
     // Draw the current cursor water level inside the well chamber
     drawWaterLevel(container, cursorWaterLevel);
-
-    // Draw each screen
-    screens.forEach((screen, index) => drawScreen(container, screen, index));
 
     return container;
 }

--- a/assets/src/scripts/components/graph/view/construction.js
+++ b/assets/src/scripts/components/graph/view/construction.js
@@ -7,7 +7,9 @@ const drawElement = function (elem, element, index) {
                 .attr('x', element.left.x)
                 .attr('y', element.left.y1)
                 .attr('width', element.right.x - element.left.x)
-                .attr('height', element.right.y2 - element.right.y1);
+                .attr('height', element.right.y2 - element.right.y1)
+                .append('title')
+                    .text(element.title);
             elem.append('line')
                 .attr('x1', element.left.x)
                 .attr('y1', element.left.y1)

--- a/assets/src/scripts/components/graph/view/construction.js
+++ b/assets/src/scripts/components/graph/view/construction.js
@@ -1,0 +1,6 @@
+export default function (elem, options, container) {
+    container = container || elem
+        .append('g');
+
+    return container;
+}

--- a/assets/src/scripts/components/graph/view/construction.js
+++ b/assets/src/scripts/components/graph/view/construction.js
@@ -1,15 +1,47 @@
 const drawCasing = function (elem, casing, index) {
-    elem.append('rect')
+    elem.append('g')
         .attr('id', `casing-${index}`)
-        .attr('x', casing.x)
-        .attr('y', casing.y)
-        .attr('width', casing.width)
-        .attr('height', casing.height)
-        .attr('fill', 'white')
-        .attr('stroke', 'wheat')
-        .attr('stroke-width', 8)
-        .attr('rx', 5)
-        .attr('ry', 5);
+        .classed('casing', true)
+        .call(elem => {
+            elem.append('rect')
+                .attr('x', casing.x)
+                .attr('y', casing.y)
+                .attr('width', casing.width)
+                .attr('height', casing.height);
+            elem.append('line')
+                .attr('x1', casing.x)
+                .attr('y1', casing.y)
+                .attr('x2', casing.x)
+                .attr('y2', casing.y + casing.height);
+            elem.append('line')
+                .attr('x1', casing.x + casing.width)
+                .attr('y1', casing.y)
+                .attr('x2', casing.x + casing.width)
+                .attr('y2', casing.y + casing.height);
+        });
+};
+
+const drawCasing2 = function (elem, casing, index) {
+    elem.append('g')
+        .attr('id', `casing-${index}`)
+        .classed('casing', true)
+        .call(elem => {
+            elem.append('rect')
+                .attr('x', casing.x)
+                .attr('y', casing.y)
+                .attr('width', casing.width)
+                .attr('height', casing.height);
+            elem.append('line')
+                .attr('x1', casing.x)
+                .attr('y1', casing.y)
+                .attr('x2', casing.x)
+                .attr('y2', casing.y + casing.height);
+            elem.append('line')
+                .attr('x1', casing.x + casing.width)
+                .attr('y1', casing.y)
+                .attr('x2', casing.x + casing.width)
+                .attr('y2', casing.y + casing.height);
+        });
 };
 
 const drawScreen = function (elem, screen, index) {
@@ -77,7 +109,7 @@ export default function (elem, {casings, screens, cursorWaterLevel}, container) 
     container.selectAll('*').remove();
 
     // Draw each casing
-    casings.forEach((casing, index) => drawCasing(container, casing, index));
+    casings.forEach((casing, index) => drawCasing2(container, casing, index));
 
     // Draw the current cursor water level inside the well chamber
     drawWaterLevel(container, cursorWaterLevel);

--- a/assets/src/scripts/components/graph/view/construction.js
+++ b/assets/src/scripts/components/graph/view/construction.js
@@ -1,6 +1,89 @@
-export default function (elem, options, container) {
+const drawCasing = function (elem, casing, index) {
+    elem.append('rect')
+        .attr('id', `casing-${index}`)
+        .attr('x', casing.x)
+        .attr('y', casing.y)
+        .attr('width', casing.width)
+        .attr('height', casing.height)
+        .attr('fill', 'white')
+        .attr('stroke', 'wheat')
+        .attr('stroke-width', 8)
+        .attr('rx', 5)
+        .attr('ry', 5);
+};
+
+const drawScreen = function (elem, screen, index) {
+    elem.append('rect')
+        .attr('id', `screen-${index}`)
+        .attr('x', screen.x)
+        .attr('y', screen.y)
+        .attr('width', screen.width)
+        .attr('height', screen.height)
+        .attr('fill', 'url(#screen-pattern)')
+        .attr('rx', 5)
+        .attr('ry', 5);
+};
+
+const drawWaterLevel = function (elem, cursorWaterLevel) {
+    // Don't draw anything if there is not a cursor datum.
+    if (!cursorWaterLevel) {
+        return;
+    }
+
+    elem.append('rect')
+        .attr('id', 'water-level')
+        .attr('x', cursorWaterLevel.x)
+        .attr('y', cursorWaterLevel.y)
+        .attr('width', cursorWaterLevel.width)
+        .attr('height', cursorWaterLevel.height)
+        .attr('fill', 'lightblue');
+};
+
+const drawPatterns = function (elem) {
+    elem.append('defs')
+        .call(defs => {
+            defs.append('mask')
+                .attr('id', 'screen-mask')
+                .attr('maskUnits', 'userSpaceOnUse')
+                .append('rect')
+                    .attr('x', '0')
+                    .attr('y', '0')
+                    .attr('width', '100%')
+                    .attr('height', '100%')
+                    .attr('fill', '#0000ff');
+
+            defs.append('pattern')
+                .attr('id', 'screen-pattern')
+                .attr('width', '3')
+                .attr('height', '3')
+                .attr('patternUnits', 'userSpaceOnUse')
+                .attr('patternTransform', 'rotate(45)')
+                .append('rect')
+                    .attr('width', '1')
+                    .attr('height', '3')
+                    .attr('transform', 'translate(0, 0)')
+                    .attr('mask', 'url(#screen-mask)');
+        });
+};
+
+export default function (elem, {casings, screens, cursorWaterLevel}, container) {
+    // Get/create container for construction elements
     container = container || elem
-        .append('g');
+        .call(drawPatterns)
+        .append('g')
+            .classed('construction', true);
+
+    // Remove any previously drawn children
+    container.selectAll('*').remove();
+
+    // Draw each casing
+    casings.forEach((casing, index) => drawCasing(container, casing, index));
+
+    // Draw the current cursor water level inside the well chamber
+    drawWaterLevel(container, cursorWaterLevel);
+
+    // Draw each screen
+    screens.forEach((screen, index) => drawScreen(container, screen, index));
 
     return container;
 }

--- a/assets/src/scripts/components/graph/view/construction.spec.js
+++ b/assets/src/scripts/components/graph/view/construction.spec.js
@@ -1,7 +1,9 @@
 import { select } from 'd3-selection';
+import { createStructuredSelector } from 'reselect';
 
 import getMockStore from 'ngwmn/store.mock';
 import drawConstruction from './construction';
+import { getConstructionElements, getWellWaterLevel } from '../state';
 
 
 describe('graph component construction', () => {
@@ -18,14 +20,17 @@ describe('graph component construction', () => {
         svg.remove();
     });
 
-    xdescribe('drawConstruction function', () => {
-
-        it('draws a screen representation', () => {
-            drawConstruction(svg, {});
+    describe('drawConstruction function', () => {
+        const selector = createStructuredSelector({
+            elements: getConstructionElements('construction'),
+            cursorWaterLevel: getWellWaterLevel('construction')
         });
 
-        it('draws a casing representation', () => {
-            drawConstruction(svg, {});
+        it('draws screen and casing representations', () => {
+            const state = store.getState();
+            drawConstruction(svg, selector(state));
+            expect(svg.select('.screen').size()).not.toBe(0);
+            expect(svg.select('.casing').size()).not.toBe(0);
         });
     });
 });

--- a/assets/src/scripts/components/graph/view/construction.spec.js
+++ b/assets/src/scripts/components/graph/view/construction.spec.js
@@ -1,0 +1,31 @@
+import { select } from 'd3-selection';
+
+import getMockStore from 'ngwmn/store.mock';
+import drawConstruction from './construction';
+
+
+describe('graph component construction', () => {
+    const store = getMockStore();
+    let svg;
+
+    beforeEach(() => {
+        svg = select('body')
+            .append('svg')
+                .attr('id', 'svg-container');
+    });
+
+    afterEach(() => {
+        svg.remove();
+    });
+
+    xdescribe('drawConstruction function', () => {
+
+        it('draws a screen representation', () => {
+            drawConstruction(svg, {});
+        });
+
+        it('draws a casing representation', () => {
+            drawConstruction(svg, {});
+        });
+    });
+});

--- a/assets/src/scripts/components/graph/view/cursor.js
+++ b/assets/src/scripts/components/graph/view/cursor.js
@@ -132,7 +132,6 @@ export const drawFocusCircle = function (elem, {cursorPoint, xScale, yScale}, ci
     // Update the location of pre-existing circles
     circles.merge(newCircles)
         .transition(transition().duration(20))
-            .style('opacity', '.6')
             .attr('cx', datum => xScale(datum.dateTime))
             .attr('cy', datum => yScale(datum.value));
 

--- a/assets/src/scripts/components/graph/view/index.js
+++ b/assets/src/scripts/components/graph/view/index.js
@@ -6,13 +6,14 @@ import { link } from 'ngwmn/lib/d3-redux';
 import { callIf } from 'ngwmn/lib/utils';
 
 import {
-    getActiveClasses, getChartPoints, getChartPosition,
+    getActiveClasses, getCasings, getChartPoints, getChartPosition,
     getCurrentWaterLevelUnit, getCursor, getCursorDatum, getLineSegments,
-    getLithology, getScaleX, getScaleY, getViewBox, setAxisYBBox, setCursor,
-    setContainerSize
+    getLithology, getScaleX, getScaleY, getScreens, getViewBox,
+    getWellWaterLevel, setAxisYBBox, setCursor, setContainerSize
 } from '../state';
 import { drawAxisX, drawAxisY, drawAxisYLabel } from './axes';
 import addBrushZoomBehavior from './brush-zoom';
+import drawConstruction from './construction';
 import { drawFocusCircle, drawFocusLine, drawTooltip } from './cursor';
 import drawDomainMapping from './domain-mapping';
 import drawLegend from './legend';
@@ -61,6 +62,11 @@ const drawChart = function (elem, store, chartType) {
                 .call(link(store, drawLithology, createStructuredSelector({
                     lithology: getLithology(chartType)
                 })))
+                .call(callIf(chartType === 'lithology', link(store, drawConstruction, createStructuredSelector({
+                    screens: getScreens(chartType),
+                    casings: getCasings(chartType),
+                    cursorWaterLevel: getWellWaterLevel(chartType)
+                }))))
                 // Draw the actual lines/circles for the current water level data set.
                 .call(link(store, drawWaterLevels, createStructuredSelector({
                     lineSegments: getLineSegments,

--- a/assets/src/scripts/components/graph/view/index.js
+++ b/assets/src/scripts/components/graph/view/index.js
@@ -6,10 +6,10 @@ import { link } from 'ngwmn/lib/d3-redux';
 import { callIf } from 'ngwmn/lib/utils';
 
 import {
-    getActiveClasses, getCasings, getChartPoints, getChartPosition,
-    getCurrentWaterLevelUnit, getCursor, getCursorDatum, getLineSegments,
-    getLithology, getScaleX, getScaleY, getScreens, getViewBox,
-    getWellWaterLevel, setAxisYBBox, setCursor, setContainerSize
+    getActiveClasses, getCasings, getChartPoints,
+    getChartPosition, getCurrentWaterLevelUnit, getCursor, getCursorDatum,
+    getLineSegments, getLithology, getScaleX, getScaleY, getScreens,
+    getViewBox, getWellWaterLevel, setAxisYBBox, setCursor, setContainerSize
 } from '../state';
 import { drawAxisX, drawAxisY, drawAxisYLabel } from './axes';
 import addBrushZoomBehavior from './brush-zoom';

--- a/assets/src/scripts/components/graph/view/index.js
+++ b/assets/src/scripts/components/graph/view/index.js
@@ -140,67 +140,69 @@ const drawChart = function (elem, store, chartType) {
 export default function (elem, store) {
     // Append a container for the graph.
     // .graph-container is used to scope all the CSS styles.
-    const graphContainer = elem.append('div')
-        .classed('graph-container', true);
+    const graphContainer = elem
+        .append('div')
+            .classed('graph-container', true);
 
     // Append the chart and axis labels, scoped to .chart-container
-    graphContainer.append('div')
-        .classed('chart-container', true)
-        // Draw the y-axis label on the left of the chart.
-        // See the SASS for the flexbox rules driving the layout.
-        .call(link(store, drawAxisYLabel, createStructuredSelector({
-            unit: getCurrentWaterLevelUnit
-        })))
-        .call(elem => {
-            // Append an SVG container that we will draw to
-            elem.append('svg')
-                .attr('xmlns', 'http://www.w3.org/2000/svg')
-                .call(link(store, (svg, viewBox) => {
-                    svg.attr('viewBox', `${viewBox.left} ${viewBox.top} ${viewBox.right - viewBox.left} ${viewBox.bottom - viewBox.top}`);
-                }, getViewBox))
-                .call(svg => {
-                    // Draw the charts
-                    const brush = drawChart(svg, store, 'brush');
-                    const main = drawChart(svg, store, 'main');
-                    drawChart(svg, store, 'lithology');
-
-                    // Draw a key mapping the domain on the main chart to the
-                    // lithology chart.
-                    svg.call(link(store, drawDomainMapping, createStructuredSelector({
-                        xScaleFrom: getScaleX('main'),
-                        yScaleFrom: getScaleY('main'),
-                        xScaleTo: getScaleX('lithology'),
-                        yScaleTo: getScaleY('lithology')
-                    })));
-
-                    // Add interactive brush and zoom behavior over the charts
-                    svg.call(addBrushZoomBehavior, store, main, brush);
-                });
-        })
+    graphContainer
         // Draw a tooltip container. This is rendered to the upper-right and
         // shows details of the point closest to the current cursor location.
         .call(link(store, drawTooltip, createStructuredSelector({
             cursorPoint: getCursorDatum,
             unit: getCurrentWaterLevelUnit
         })))
-        .call(div => {
-            // Create an observer on the .chart-container node.
-            // Here, we use a ResizeObserver polyfill to trigger redraws when
-            // the CSS-driven size of our container changes.
-            const node = div.node();
-            let size = {};
-            const observer = new ResizeObserver(function (entries) {
-                const newSize = {
-                    width: parseFloat(entries[0].contentRect.width),
-                    height: parseFloat(entries[0].contentRect.height)
-                };
-                if (size.width !== newSize.width || size.height !== newSize.height) {
-                    size = newSize;
-                    store.dispatch(setContainerSize(size));
-                }
+        .append('div')
+            .classed('chart-container', true)
+            // Draw the y-axis label on the left of the chart.
+            // See the SASS for the flexbox rules driving the layout.
+            .call(link(store, drawAxisYLabel, createStructuredSelector({
+                unit: getCurrentWaterLevelUnit
+            })))
+            .call(elem => {
+                // Append an SVG container that we will draw to
+                elem.append('svg')
+                    .attr('xmlns', 'http://www.w3.org/2000/svg')
+                    .call(link(store, (svg, viewBox) => {
+                        svg.attr('viewBox', `${viewBox.left} ${viewBox.top} ${viewBox.right - viewBox.left} ${viewBox.bottom - viewBox.top}`);
+                    }, getViewBox))
+                    .call(svg => {
+                        // Draw the charts
+                        const brush = drawChart(svg, store, 'brush');
+                        const main = drawChart(svg, store, 'main');
+                        drawChart(svg, store, 'lithology');
+
+                        // Draw a key mapping the domain on the main chart to the
+                        // lithology chart.
+                        svg.call(link(store, drawDomainMapping, createStructuredSelector({
+                            xScaleFrom: getScaleX('main'),
+                            yScaleFrom: getScaleY('main'),
+                            xScaleTo: getScaleX('lithology'),
+                            yScaleTo: getScaleY('lithology')
+                        })));
+
+                        // Add interactive brush and zoom behavior over the charts
+                        svg.call(addBrushZoomBehavior, store, main, brush);
+                    });
+            })
+            .call(div => {
+                // Create an observer on the .chart-container node.
+                // Here, we use a ResizeObserver polyfill to trigger redraws when
+                // the CSS-driven size of our container changes.
+                const node = div.node();
+                let size = {};
+                const observer = new ResizeObserver(function (entries) {
+                    const newSize = {
+                        width: parseFloat(entries[0].contentRect.width),
+                        height: parseFloat(entries[0].contentRect.height)
+                    };
+                    if (size.width !== newSize.width || size.height !== newSize.height) {
+                        size = newSize;
+                        store.dispatch(setContainerSize(size));
+                    }
+                });
+                observer.observe(node);
             });
-            observer.observe(node);
-        });
 
     // Append the legend
     graphContainer

--- a/assets/src/scripts/components/graph/view/index.js
+++ b/assets/src/scripts/components/graph/view/index.js
@@ -101,7 +101,7 @@ const drawChart = function (elem, store, chartType) {
         }))))
         // To capture mouse events, draw an overlay rect and attach event
         // handlers to it.
-        .call(g => {
+        .call(callIf(chartType !== 'construction', g => {
             g.append('rect')
                 .attr('class', 'overlay')
                 // Set the overlay size, including a little extra space to deal
@@ -127,7 +127,7 @@ const drawChart = function (elem, store, chartType) {
                         store.dispatch(setCursor(selectedTime));
                     });
                 }, getScaleX(chartType)));
-        });
+        }));
 };
 
 /**

--- a/assets/src/scripts/components/graph/view/index.js
+++ b/assets/src/scripts/components/graph/view/index.js
@@ -59,26 +59,26 @@ const drawChart = function (elem, store, chartType) {
             elem.append('g')
                 .attr('clip-path', `url(#${chartType}-clip-path)`)
                 // Draw well log lithology background
-                .call(link(store, drawLithology, createStructuredSelector({
+                .call(callIf(chartType !== 'construction', link(store, drawLithology, createStructuredSelector({
                     lithology: getLithology(chartType)
-                })))
-                .call(callIf(chartType === 'lithology', link(store, drawConstruction, createStructuredSelector({
+                }))))
+                .call(callIf(chartType === 'construction', link(store, drawConstruction, createStructuredSelector({
                     elements: getConstructionElements(chartType),
                     cursorWaterLevel: getWellWaterLevel(chartType)
                 }))))
                 // Draw the actual lines/circles for the current water level data set.
-                .call(link(store, drawWaterLevels, createStructuredSelector({
+                .call(callIf(chartType !== 'construction', link(store, drawWaterLevels, createStructuredSelector({
                     lineSegments: getLineSegments,
                     chartPoints: getChartPoints,
                     xScale: getScaleX(chartType),
                     yScale: getScaleY(chartType)
-                }), chartType))
+                }), chartType)))
                 // Draw a vertical focus line representing the current cursor location.
-                .call(link(store, drawFocusLine, createStructuredSelector({
+                .call(callIf(chartType !== 'construction', link(store, drawFocusLine, createStructuredSelector({
                     cursor: getCursor,
                     xScale: getScaleX(chartType),
                     yScale: getScaleY(chartType)
-                })))
+                }))))
                 // Draw a circle around the point nearest the current cursor location.
                 .call(callIf(chartType === 'main', link(store, drawFocusCircle, createStructuredSelector({
                     cursorPoint: getCursorDatum,
@@ -170,6 +170,7 @@ export default function (elem, store) {
                         const brush = drawChart(svg, store, 'brush');
                         const main = drawChart(svg, store, 'main');
                         drawChart(svg, store, 'lithology');
+                        drawChart(svg, store, 'construction');
 
                         // Draw a key mapping the domain on the main chart to the
                         // lithology chart.

--- a/assets/src/scripts/components/graph/view/index.js
+++ b/assets/src/scripts/components/graph/view/index.js
@@ -6,10 +6,10 @@ import { link } from 'ngwmn/lib/d3-redux';
 import { callIf } from 'ngwmn/lib/utils';
 
 import {
-    getActiveClasses, getCasings, getChartPoints,
-    getChartPosition, getCurrentWaterLevelUnit, getCursor, getCursorDatum,
-    getLineSegments, getLithology, getScaleX, getScaleY, getScreens,
-    getViewBox, getWellWaterLevel, setAxisYBBox, setCursor, setContainerSize
+    getActiveClasses, getChartPoints, getChartPosition, getConstructionElements,
+    getCurrentWaterLevelUnit, getCursor, getCursorDatum,
+    getLineSegments, getLithology, getScaleX, getScaleY, getViewBox,
+    getWellWaterLevel, setAxisYBBox, setCursor, setContainerSize
 } from '../state';
 import { drawAxisX, drawAxisY, drawAxisYLabel } from './axes';
 import addBrushZoomBehavior from './brush-zoom';
@@ -63,8 +63,7 @@ const drawChart = function (elem, store, chartType) {
                     lithology: getLithology(chartType)
                 })))
                 .call(callIf(chartType === 'lithology', link(store, drawConstruction, createStructuredSelector({
-                    screens: getScreens(chartType),
-                    casings: getCasings(chartType),
+                    elements: getConstructionElements(chartType),
                     cursorWaterLevel: getWellWaterLevel(chartType)
                 }))))
                 // Draw the actual lines/circles for the current water level data set.

--- a/assets/src/scripts/components/graph/view/lithology.js
+++ b/assets/src/scripts/components/graph/view/lithology.js
@@ -3,7 +3,7 @@ import { transition } from 'd3-transition';
 const LITHOLOGY_COLORS = [
     '#9A887E',
     '#72655C',
-    '#CDE569',
+    '#F0E68C',
     '#C6BBB7'
 ];
 

--- a/assets/src/scripts/components/graph/view/water-levels.js
+++ b/assets/src/scripts/components/graph/view/water-levels.js
@@ -69,7 +69,9 @@ export default function (svg, {lineSegments, chartPoints, xScale, yScale}, chart
         );
     });
 
-    if (chartType !== 'lithology') {
+    // If this is the main chart, draw a blue polygon overlay representing the
+    // water table level.
+    if (chartType === 'main') {
         context.area
             .datum(chartPoints)
             .transition(transition().duration(25))

--- a/assets/src/scripts/index.spec.js
+++ b/assets/src/scripts/index.spec.js
@@ -15,6 +15,7 @@ import 'ngwmn/components/graph/state/points.spec.js';
 import 'ngwmn/components/graph/state/scales.spec.js';
 import 'ngwmn/components/graph/state/well-log.spec.js';
 import 'ngwmn/components/graph/view/axes.spec.js';
+import 'ngwmn/components/graph/view/construction.spec.js';
 import 'ngwmn/components/graph/view/cursor.spec.js';
 import 'ngwmn/components/graph/view/domain-mapping.spec.js';
 import 'ngwmn/components/graph/view/legend.spec.js';

--- a/assets/src/scripts/index.spec.js
+++ b/assets/src/scripts/index.spec.js
@@ -10,10 +10,10 @@
 import 'ngwmn/components/graph/index.spec.js';
 import 'ngwmn/components/graph/state/cursor.spec.js';
 import 'ngwmn/components/graph/state/layout.spec.js';
-import 'ngwmn/components/graph/state/lithology.spec.js';
 import 'ngwmn/components/graph/state/options.spec.js';
 import 'ngwmn/components/graph/state/points.spec.js';
 import 'ngwmn/components/graph/state/scales.spec.js';
+import 'ngwmn/components/graph/state/well-log.spec.js';
 import 'ngwmn/components/graph/view/axes.spec.js';
 import 'ngwmn/components/graph/view/cursor.spec.js';
 import 'ngwmn/components/graph/view/domain-mapping.spec.js';

--- a/assets/src/scripts/store.mock.json
+++ b/assets/src/scripts/store.mock.json
@@ -2,14 +2,14 @@
     "components/graph/cursor": {},
     "components/graph/layout": {
         "axisYBBox": {
-            "height": 527.8174438476562,
+            "height": 574.5460815429688,
             "width": 28.9375,
             "x": -28.4375,
             "y": 0.5
         },
         "graphSize": {
-            "height": 639.109375,
-            "width": 1065.1875
+            "height": 698.140625,
+            "width": 1199.59375
         },
         "viewport": [
             1334034000000,
@@ -272,11 +272,11 @@
     },
     "services/wellLog": {
         "KSGS:381107098532401": {
-            "casings": [
+            "construction": [
                 {
                     "diameter": {
                         "unit": "in",
-                        "value": "16"
+                        "value": 16
                     },
                     "material": "PVC",
                     "position": {
@@ -285,7 +285,38 @@
                             "start": 0
                         },
                         "unit": "ft"
-                    }
+                    },
+                    "type": "casing"
+                },
+                {
+                    "diameter": {
+                        "unit": "in",
+                        "value": null
+                    },
+                    "material": "PVC",
+                    "position": {
+                        "coordinates": {
+                            "end": 90.8,
+                            "start": 80.8
+                        },
+                        "unit": "ft"
+                    },
+                    "type": "screen"
+                },
+                {
+                    "diameter": {
+                        "unit": "in",
+                        "value": null
+                    },
+                    "material": "PVC",
+                    "position": {
+                        "coordinates": {
+                            "end": 212.8,
+                            "start": 152.8
+                        },
+                        "unit": "ft"
+                    },
+                    "type": "screen"
                 }
             ],
             "elevation": {
@@ -904,36 +935,6 @@
                 }
             ],
             "name": "KSGS.381107098532401",
-            "screens": [
-                {
-                    "diameter": {
-                        "unit": "in",
-                        "value": null
-                    },
-                    "material": "PVC",
-                    "position": {
-                        "coordinates": {
-                            "end": 90.8,
-                            "start": 80.8
-                        },
-                        "unit": "ft"
-                    }
-                },
-                {
-                    "diameter": {
-                        "unit": "in",
-                        "value": null
-                    },
-                    "material": "PVC",
-                    "position": {
-                        "coordinates": {
-                            "end": 212.8,
-                            "start": 152.8
-                        },
-                        "unit": "ft"
-                    }
-                }
-            ],
             "water_use": "urn:OGC:unknown",
             "well_depth": {
                 "unit": "ft",

--- a/assets/src/scripts/store.mock.json
+++ b/assets/src/scripts/store.mock.json
@@ -1,17 +1,15 @@
 {
-    "components/graph/cursor": {
-        "date": null
-    },
+    "components/graph/cursor": {},
     "components/graph/layout": {
         "axisYBBox": {
-            "height": 612.6797485351562,
+            "height": 527.8174438476562,
             "width": 28.9375,
             "x": -28.4375,
             "y": 0.5
         },
         "graphSize": {
-            "height": 745.1875,
-            "width": 1242
+            "height": 639.109375,
+            "width": 1065.1875
         },
         "viewport": [
             1334034000000,
@@ -283,8 +281,8 @@
                     "material": "PVC",
                     "position": {
                         "coordinates": {
-                            "end": "80.9",
-                            "start": "0"
+                            "end": 80.9,
+                            "start": 0
                         },
                         "unit": "ft"
                     }
@@ -293,7 +291,7 @@
             "elevation": {
                 "scheme": "NAVD88",
                 "unit": "ft",
-                "value": "1950"
+                "value": 1950
             },
             "link": {
                 "title": "Kansas Geological Survey",
@@ -327,8 +325,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "2",
-                            "start": "0"
+                            "end": 2,
+                            "start": 0
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -357,8 +355,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "6",
-                            "start": "2"
+                            "end": 6,
+                            "start": 2
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -387,8 +385,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "8",
-                            "start": "6"
+                            "end": 8,
+                            "start": 6
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -417,8 +415,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "16",
-                            "start": "8"
+                            "end": 16,
+                            "start": 8
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -447,8 +445,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "21",
-                            "start": "16"
+                            "end": 21,
+                            "start": 16
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -477,8 +475,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "23",
-                            "start": "21"
+                            "end": 23,
+                            "start": 21
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -507,8 +505,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "25",
-                            "start": "23"
+                            "end": 25,
+                            "start": 23
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -537,8 +535,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "39",
-                            "start": "25"
+                            "end": 39,
+                            "start": 25
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -567,8 +565,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "53",
-                            "start": "39"
+                            "end": 53,
+                            "start": 39
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -597,8 +595,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "73",
-                            "start": "53"
+                            "end": 73,
+                            "start": 53
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -627,8 +625,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "74",
-                            "start": "73"
+                            "end": 74,
+                            "start": 73
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -657,8 +655,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "79",
-                            "start": "74"
+                            "end": 79,
+                            "start": 74
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -687,8 +685,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "90",
-                            "start": "79"
+                            "end": 90,
+                            "start": 79
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -717,8 +715,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "110",
-                            "start": "90"
+                            "end": 110,
+                            "start": 90
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -747,8 +745,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "120",
-                            "start": "110"
+                            "end": 120,
+                            "start": 110
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -777,8 +775,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "128",
-                            "start": "120"
+                            "end": 128,
+                            "start": 120
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -807,8 +805,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "130",
-                            "start": "128"
+                            "end": 130,
+                            "start": 128
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -837,8 +835,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "151",
-                            "start": "130"
+                            "end": 151,
+                            "start": 130
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -867,8 +865,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "212",
-                            "start": "151"
+                            "end": 212,
+                            "start": 151
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -897,8 +895,8 @@
                     "method": "Drilling Log",
                     "shape": {
                         "coordinates": {
-                            "end": "214",
-                            "start": "212"
+                            "end": 214,
+                            "start": 212
                         },
                         "dimension": "1",
                         "unit": "ft"
@@ -915,8 +913,8 @@
                     "material": "PVC",
                     "position": {
                         "coordinates": {
-                            "end": "90.8",
-                            "start": "80.8"
+                            "end": 90.8,
+                            "start": 80.8
                         },
                         "unit": "ft"
                     }
@@ -929,8 +927,8 @@
                     "material": "PVC",
                     "position": {
                         "coordinates": {
-                            "end": "212.8",
-                            "start": "152.8"
+                            "end": 212.8,
+                            "start": 152.8
                         },
                         "unit": "ft"
                     }
@@ -939,7 +937,7 @@
             "water_use": "urn:OGC:unknown",
             "well_depth": {
                 "unit": "ft",
-                "value": "214"
+                "value": 214
             }
         }
     }

--- a/assets/src/styles/components/_graph.scss
+++ b/assets/src/styles/components/_graph.scss
@@ -146,6 +146,9 @@ $provisional-color: color(accent-warm, dark);
                         rect {
                             fill: white;
                             fill-opacity: 0.75;
+                            &:hover {
+                                fill: yellow;
+                            }
                         }
                     }
                     .screen {
@@ -162,7 +165,6 @@ $provisional-color: color(accent-warm, dark);
                                 fill: url(#screen-0);
                             }
                             &:hover {
-                                pointer-events: all;
                                 fill: yellow;
                                 fill-opacity: 0.75;
                             }

--- a/assets/src/styles/components/_graph.scss
+++ b/assets/src/styles/components/_graph.scss
@@ -138,14 +138,35 @@ $provisional-color: color(accent-warm, dark);
                         }
                     }
                 }
-                g.casing {
-                    line {
-                        stroke: gray;
-                        stroke-width: 10;
-                        stroke-linecap: round;
+                g.construction {
+                    .casing {
+                        line {
+                            stroke: gray;
+                        }
+                        rect {
+                            fill: white;
+                            fill-opacity: 0.75;
+                        }
                     }
-                    rect {
-                        fill: white;
+                    .screen {
+                        line {
+                            stroke: gray;
+                            stroke-linecap: round;
+                        }
+                        rect {
+                            fill-opacity: 1;
+                            &:nth-child(odd) {
+                                fill: url(#screen-0);
+                            }
+                            &:nth-child(even) {
+                                fill: url(#screen-0);
+                            }
+                            &:hover {
+                                pointer-events: all;
+                                fill: yellow;
+                                fill-opacity: 0.75;
+                            }
+                        }
                     }
                 }
             }

--- a/assets/src/styles/components/_graph.scss
+++ b/assets/src/styles/components/_graph.scss
@@ -70,6 +70,22 @@ $provisional-color: color(accent-warm, dark);
         display: flex;
         flex-direction: column;
         flex-grow: 1;
+        .tooltip {
+            text-align: right;
+            pointer-events: none;
+            background: rgba(255, 255, 255, 0.8);
+            color: $default-color;
+            .current-tooltip-text {
+                font-weight: bold;
+            }
+            color: $approved-color;
+            .provisional {
+                color: $provisional-color;
+            }
+            .compare-tooltip-text {
+                font-weight: normal
+            }
+        }
         .chart-container {
             flex-grow: 1;
             display: flex;
@@ -107,8 +123,8 @@ $provisional-color: color(accent-warm, dark);
                         pointer-events: all;
                     }
                     circle.focus {
-                        fill: #436BAF;
-                        opacity: .6;
+                        fill: $accent-warm;
+                        opacity: .9;
                     }
                     .focus {
                         line {
@@ -124,23 +140,6 @@ $provisional-color: color(accent-warm, dark);
             path.domain-mapping {
                 fill: none;
                 stroke: $secondary;
-            }
-            .tooltip {
-                pointer-events: none;
-                position: absolute;
-                right: 0;
-                background: rgba(255, 255, 255, 0.8);
-                color: $default-color;
-                .current-tooltip-text {
-                    font-weight: bold;
-                }
-                color: $approved-color;
-                .provisional {
-                    color: $provisional-color;
-                }
-                .compare-tooltip-text {
-                    font-weight: normal
-                }
             }
         }
         .legend {

--- a/assets/src/styles/components/_graph.scss
+++ b/assets/src/styles/components/_graph.scss
@@ -106,6 +106,8 @@ $provisional-color: color(accent-warm, dark);
                     }
                     path.line-segment {
                         fill: none;
+                        stroke-linejoin: round;
+                        stroke-linecap: round;
                     }
                     .line-segment {
                         stroke-width: 2px;
@@ -134,6 +136,16 @@ $provisional-color: color(accent-warm, dark);
                             stroke-width: 1px;
                             stroke-dasharray: 5, 5
                         }
+                    }
+                }
+                g.casing {
+                    line {
+                        stroke: gray;
+                        stroke-width: 10;
+                        stroke-linecap: round;
+                    }
+                    rect {
+                        fill: white;
                     }
                 }
             }

--- a/assets/src/styles/components/_graph.scss
+++ b/assets/src/styles/components/_graph.scss
@@ -145,7 +145,7 @@ $provisional-color: color(accent-warm, dark);
                         }
                         rect {
                             fill: white;
-                            fill-opacity: 0.75;
+                            fill-opacity: 0.25;
                             &:hover {
                                 fill: yellow;
                             }
@@ -158,12 +158,6 @@ $provisional-color: color(accent-warm, dark);
                         }
                         rect {
                             fill-opacity: 1;
-                            &:nth-child(odd) {
-                                fill: url(#screen-0);
-                            }
-                            &:nth-child(even) {
-                                fill: url(#screen-0);
-                            }
                             &:hover {
                                 fill: yellow;
                                 fill-opacity: 0.75;

--- a/assets/src/styles/pages/_site_location.scss
+++ b/assets/src/styles/pages/_site_location.scss
@@ -3,3 +3,7 @@
     margin-left: 0px;
     margin-top: 0px;
 }
+
+ h1, h2 {
+    margin: 0;
+ }

--- a/server/ngwmn/services/ngwmn.py
+++ b/server/ngwmn/services/ngwmn.py
@@ -239,7 +239,7 @@ def get_well_log(agency_cd, location_id):
             })(casing.find('gwml:position/gml:LineString', xml.nsmap)),
             'material': _find(casing, 'gwml:material/gsml:CGI_TermValue/gsml:value'),
             'diameter': (lambda dimension: {
-                'value': dimension.text,
+                'value': _cast(float, dimension.text),
                 'unit': _default(dimension.get('uom'), 'ft')
             })(casing.find('gwml:nominalPipeDimension/gsml:CGI_NumericValue/gsml:principalValue', xml.nsmap))
         } for casing in water_well.findall('gwml:construction/gwml:WellCasing/gwml:wellCasingElement/gwml:WellCasingComponent', xml.nsmap)],
@@ -250,7 +250,7 @@ def get_well_log(agency_cd, location_id):
             })(screen.find('gwml:position/gml:LineString', xml.nsmap)),
             'material': _find(screen, 'gwml:material/gsml:CGI_TermValue/gsml:value'),
             'diameter': (lambda dimension: {
-                'value': dimension.text,
+                'value': _cast(float, dimension.text),
                 'unit': _default(dimension.get('uom'), 'ft')
             })(screen.find('gwml:nomicalScreenDiameter/gsml:CGI_NumericValue/gsml:principalValue', xml.nsmap))
         } for screen in water_well.findall('gwml:construction/gwml:Screen/gwml:screenElement/gwml:ScreenComponent', xml.nsmap)]

--- a/server/ngwmn/services/ngwmn.py
+++ b/server/ngwmn/services/ngwmn.py
@@ -83,7 +83,8 @@ def _coordinates(value):
         'end': _cast(float, coordinates[1])
     }
 
-def get_water_quality_activities(agency_cd, location_id):
+
+def get_water_quality(agency_cd, location_id):
     """
     Retrieves water-quality data from the NGWMN iddata service.
 
@@ -94,70 +95,76 @@ def get_water_quality_activities(agency_cd, location_id):
     """
     xml = get_iddata('water_quality', agency_cd, location_id)
     if xml is None:
-        return []
+        return {}
 
     organization = xml.find('.//Organization', xml.nsmap)
     if organization is None:
-        return []
+        return {}
 
-    return [{
-        'description': (lambda desc: {
-            'identifier': _find(desc, 'ActivityIdentifier'),
-            'type_code': _find(desc, 'ActivityTypeCode'),
-            'media_name': _find(desc, 'ActivityMediaName'),
-            'start_date': _find(desc, 'ActivityStartDate'),
-            'start_time': (lambda time: {
-                'time': _find(time, 'Time'),
-                'time_zone_code': _find(time, 'TimeZoneCode')
-            })(desc.find('ActivityStartTime', xml.nsmap)),
-            'project_identifier': _find(desc, 'ProjectIdentifier'),
-            'monitoring_location_identifier': _find(desc, 'MonitoringLocationIdentifier'),
-            'comment_text': _find(desc, 'ActivityCommentText')
-        })(activity.find('ActivityDescription', xml.nsmap)),
-        'sample_description': (lambda desc: {
-            'collection_method': (lambda method: {
-                'identifier': _find(method, 'MethodIdentifier'),
-                'identifier_context': _find(method, 'MethodIdentifierContext'),
-                'name': _find(method, 'MethodName')
-            })(desc.find('SampleCollectionMethod', xml.nsmap)),
-            'collection_equipment_name': _find(desc, 'SampleCollectionEquipmentName')
-        })(activity.find('SampleDescription', xml.nsmap)),
-        'results': [{
-            'pcode': _find(result, 'USGSPcode'),
-            'provider_name': _find(result, 'ProviderName'),
+    return {
+        'organization': (lambda desc: {
+            'id': _find(desc, 'OrganizationIdentifier'),
+            'name': _find(desc, 'OrganizationFormalName')
+        })(organization.find('OrganizationDescription', xml.nsmap)),
+        'activities': [{
             'description': (lambda desc: {
-                'detection_condition_text': _find(desc, 'ResultDetectionConditionText'),
-                'characteristic_name': _find(desc, 'CharacteristicName'),
-                'sample_fraction_text': _find(desc, 'ResultSampleFractionText'),
-                'measure': (lambda measure: {
-                    'value': _find(measure, 'ResultMeasureValue'),
-                    'unit_code': _find(measure, 'MeasureUnitCode'),
-                })(desc.find('ResultMeasure', xml.nsmap)),
-                'value_type_name': _find(desc, 'ResultValueTypeName'),
-                'temperature_basis_text': _find(desc, 'ResultTemperatureBasisText'),
-                'comment_text': _find(desc, 'ResultCommentText')
-            })(result.find('ResultDescription', xml.nsmap)),
-            'analytical_method': (lambda method: {
-                'identifier': _find(method, 'MethodIdentifier'),
-                'identifier_context': _find(method, 'MethodIdentifierContext'),
-                'name': _find(method, 'MethodName')
-            })(result.find('ResultAnalyticalMethod', xml.nsmap)),
-            'lab_information': (lambda info: {
-                'analysis_start_date': _find(info, 'AnalysisStartDate'),
-                'analysis_start_time': (lambda start_time: {
-                    'time': _find(start_time, 'Time'),
-                    'time_zone_code': _find(start_time, 'TimeZoneCode')
-                })(info.find('AnalysisStartTime', xml.nsmap) if info is not None else None),
-                'detection_quantitation_limit': (lambda limit: {
-                    'type_name': _find(limit, 'DetectionQuantitationLimitTypeName'),
+                'identifier': _find(desc, 'ActivityIdentifier'),
+                'type_code': _find(desc, 'ActivityTypeCode'),
+                'media_name': _find(desc, 'ActivityMediaName'),
+                'start_date': _find(desc, 'ActivityStartDate'),
+                'start_time': (lambda time: {
+                    'time': _find(time, 'Time'),
+                    'time_zone_code': _find(time, 'TimeZoneCode')
+                })(desc.find('ActivityStartTime', xml.nsmap)),
+                'project_identifier': _find(desc, 'ProjectIdentifier'),
+                'monitoring_location_identifier': _find(desc, 'MonitoringLocationIdentifier'),
+                'comment_text': _find(desc, 'ActivityCommentText')
+            })(activity.find('ActivityDescription', xml.nsmap)),
+            'sample_description': (lambda desc: {
+                'collection_method': (lambda method: {
+                    'identifier': _find(method, 'MethodIdentifier'),
+                    'identifier_context': _find(method, 'MethodIdentifierContext'),
+                    'name': _find(method, 'MethodName')
+                })(desc.find('SampleCollectionMethod', xml.nsmap)),
+                'collection_equipment_name': _find(desc, 'SampleCollectionEquipmentName')
+            })(activity.find('SampleDescription', xml.nsmap)),
+            'results': [{
+                'pcode': _find(result, 'USGSPcode'),
+                'provider_name': _find(result, 'ProviderName'),
+                'description': (lambda desc: {
+                    'detection_condition_text': _find(desc, 'ResultDetectionConditionText'),
+                    'characteristic_name': _find(desc, 'CharacteristicName'),
+                    'sample_fraction_text': _find(desc, 'ResultSampleFractionText'),
                     'measure': (lambda measure: {
-                        'value': _find(measure, 'MeasureValue'),
-                        'unit_code': _find(measure, 'MeasureUnitCode')
-                    })(limit.find('DetectionQuantitationLimitMeasure', xml.nsmap) if limit is not None else None)
-                })(info.find('ResultDetectionQuantitationLimit', xml.nsmap) if info is not None else None)
-            })(result.find('ResultLabInformation', xml.nsmap))
-        } for result in activity.findall('Result', xml.nsmap)]
-    } for activity in organization.findall('Activity', xml.nsmap)]
+                        'value': _find(measure, 'ResultMeasureValue'),
+                        'unit_code': _find(measure, 'MeasureUnitCode'),
+                    })(desc.find('ResultMeasure', xml.nsmap)),
+                    'value_type_name': _find(desc, 'ResultValueTypeName'),
+                    'temperature_basis_text': _find(desc, 'ResultTemperatureBasisText'),
+                    'comment_text': _find(desc, 'ResultCommentText')
+                })(result.find('ResultDescription', xml.nsmap)),
+                'analytical_method': (lambda method: {
+                    'identifier': _find(method, 'MethodIdentifier'),
+                    'identifier_context': _find(method, 'MethodIdentifierContext'),
+                    'name': _find(method, 'MethodName')
+                })(result.find('ResultAnalyticalMethod', xml.nsmap)),
+                'lab_information': (lambda info: {
+                    'analysis_start_date': _find(info, 'AnalysisStartDate'),
+                    'analysis_start_time': (lambda start_time: {
+                        'time': _find(start_time, 'Time'),
+                        'time_zone_code': _find(start_time, 'TimeZoneCode')
+                    })(info.find('AnalysisStartTime', xml.nsmap) if info is not None else None),
+                    'detection_quantitation_limit': (lambda limit: {
+                        'type_name': _find(limit, 'DetectionQuantitationLimitTypeName'),
+                        'measure': (lambda measure: {
+                            'value': _find(measure, 'MeasureValue'),
+                            'unit_code': _find(measure, 'MeasureUnitCode')
+                        })(limit.find('DetectionQuantitationLimitMeasure', xml.nsmap) if limit is not None else None)
+                    })(info.find('ResultDetectionQuantitationLimit', xml.nsmap) if info is not None else None)
+                })(result.find('ResultLabInformation', xml.nsmap))
+            } for result in activity.findall('Result', xml.nsmap)]
+        } for activity in organization.findall('Activity', xml.nsmap)]
+    }
 
 
 def get_well_log(agency_cd, location_id):

--- a/server/ngwmn/services/ngwmn.py
+++ b/server/ngwmn/services/ngwmn.py
@@ -232,28 +232,29 @@ def get_well_log(agency_cd, location_id):
                 'coordinates': _coordinates(_find(shape, 'gml:coordinates'))
             })(entry.find('gsml:shape/gml:LineString', xml.nsmap)),
         } for entry in water_well.findall('gwml:logElement/gsml:MappedInterval', xml.nsmap)],
-        'casings': [{
+        'construction': [{
+            'type': 'casing',
             'position': (lambda line: {
                 'unit': _default(_find(line, 'gml:uom'), 'ft'),
                 'coordinates': _coordinates(_find(line, 'gml:coordinates'))
-            })(casing.find('gwml:position/gml:LineString', xml.nsmap)),
-            'material': _find(casing, 'gwml:material/gsml:CGI_TermValue/gsml:value'),
+            })(elem.find('gwml:position/gml:LineString', xml.nsmap)),
+            'material': _find(elem, 'gwml:material/gsml:CGI_TermValue/gsml:value'),
             'diameter': (lambda dimension: {
                 'value': _cast(float, dimension.text),
-                'unit': _default(dimension.get('uom'), 'ft')
-            })(casing.find('gwml:nominalPipeDimension/gsml:CGI_NumericValue/gsml:principalValue', xml.nsmap))
-        } for casing in water_well.findall('gwml:construction/gwml:WellCasing/gwml:wellCasingElement/gwml:WellCasingComponent', xml.nsmap)],
-        'screens': [{
+                'unit': _default(dimension.get('uom'), 'in')
+            })(elem.find('gwml:nominalPipeDimension/gsml:CGI_NumericValue/gsml:principalValue', xml.nsmap))
+        } for elem in water_well.findall('gwml:construction/gwml:WellCasing/gwml:wellCasingElement/gwml:WellCasingComponent', xml.nsmap)] + [{
+            'type': 'screen',
             'position': (lambda line: {
                 'unit': _default(_find(line, 'gml:uom'), 'ft'),
                 'coordinates': _coordinates(_find(line, 'gml:coordinates'))
-            })(screen.find('gwml:position/gml:LineString', xml.nsmap)),
-            'material': _find(screen, 'gwml:material/gsml:CGI_TermValue/gsml:value'),
+            })(elem.find('gwml:position/gml:LineString', xml.nsmap)),
+            'material': _find(elem, 'gwml:material/gsml:CGI_TermValue/gsml:value'),
             'diameter': (lambda dimension: {
                 'value': _cast(float, dimension.text),
-                'unit': _default(dimension.get('uom'), 'ft')
-            })(screen.find('gwml:nomicalScreenDiameter/gsml:CGI_NumericValue/gsml:principalValue', xml.nsmap))
-        } for screen in water_well.findall('gwml:construction/gwml:Screen/gwml:screenElement/gwml:ScreenComponent', xml.nsmap)]
+                'unit': _default(dimension.get('uom'), 'in')
+            })(elem.find('gwml:nomicalScreenDiameter/gsml:CGI_NumericValue/gsml:principalValue', xml.nsmap))
+        } for elem in water_well.findall('gwml:construction/gwml:Screen/gwml:screenElement/gwml:ScreenComponent', xml.nsmap)]
     }
 
 

--- a/server/ngwmn/templates/site_location.html
+++ b/server/ngwmn/templates/site_location.html
@@ -2,7 +2,11 @@
 
 {% import 'macros/components.html' as components %}
 
-{% set page_title = feature.SITE_NAME %}
+{% if organization %}
+    {% set page_title = feature.SITE_NAME + ' - ' + organization %}
+{% else %}
+    {% set page_title = feature.SITE_NAME %}
+{% endif %}
 {% set body_id = 'site-location' %}
 
 {% block page_script %}<script>window.wellLog = {{ well_log | tojson | safe }}</script>{% endblock %}
@@ -12,7 +16,8 @@
 {%- endmacro %}
 
 {% block content %}
-    <h1 class="usa-heading">{{ feature.SITE_NAME }}</h1>
+    <h1>{{ feature.SITE_NAME }}</h1>
+    {% if organization %}<h2 class="usa-font-lead">{{ organization }}</h2>{% endif %}
     <div class="usa-grid">
         {{ components.Graph(feature.AGENCY_CD, feature.SITE_NO) }}
         <ul class="usa-accordion">

--- a/server/ngwmn/templates/site_location.html
+++ b/server/ngwmn/templates/site_location.html
@@ -194,14 +194,14 @@
                             <th scope="col">Material</th>
                         </thead>
                         <tbody>
-                            {% for casing in well_log.casings %}
+                            {% for casing in well_log.construction %}{% if casing.type == 'casing' %}
                                 <tr>
                                     <td>{{ casing.position.coordinates.start }} {{ casing.position.unit }}</td>
                                     <td>{{ casing.position.coordinates.end }} {{ casing.position.unit }}</td>
                                     <td>{% if casing.diameter.value %}{{ casing.diameter.value }} {{ casing.diameter.unit }}{% endif %}</td>
                                     <td>{{ _(casing.material) }}</td>
                                 </tr>
-                            {% endfor %}
+                            {% endif %}{% endfor %}
                         </tbody>
                     </table>
                     <table class="usa-table-borderless">
@@ -213,14 +213,14 @@
                             <th scope="col">Material</th>
                         </thead>
                         <tbody>
-                            {% for screen in well_log.screens %}
+                            {% for screen in well_log.construction %}{% if screen.type == 'screen' %}
                                 <tr>
                                     <td>{{ screen.position.coordinates.start }} {{ screen.position.unit }}</td>
                                     <td>{{ screen.position.coordinates.end }} {{ screen.position.unit }}</td>
                                     <td>{% if screen.diameter.value %}{{ screen.diameter.value }} {{ screen.diameter.unit }}{% endif %}</td>
                                     <td>{{ _(screen.material) }}</td>
                                 </tr>
-                            {% endfor %}
+                            {% endif %}{% endfor %}
                         </tbody>
                     </table>
                 </div>

--- a/server/ngwmn/tests/services/test_ngwmn.py
+++ b/server/ngwmn/tests/services/test_ngwmn.py
@@ -9,8 +9,7 @@ import requests_mock
 
 from ngwmn.services import ServiceException
 from ngwmn.services.ngwmn import (
-    generate_bounding_box_values, get_iddata, get_water_quality_activities,
-    get_well_log)
+    generate_bounding_box_values, get_iddata, get_water_quality, get_well_log)
 
 
 class TestGetWellLithography(TestCase):
@@ -83,8 +82,12 @@ class TestWaterQualityResults(TestCase):
     def test_wq_parsing(self):
         with requests_mock.mock() as req:
             req.get(requests_mock.ANY, content=MOCK_WQ_RESPONSE)
-            results = get_water_quality_activities('USGS', 1)
-            self.assertEqual(results, [{
+            results = get_water_quality('USGS', 1)
+            self.assertEqual(results['organization'], {
+                'id': 'USGS-MI',
+                'name': 'USGS Michigan Water Science Center'
+            })
+            self.assertEqual(results['activities'], [{
                 'description': {
                     'comment_text': 'Test comment',
                     'identifier': 'nwismi.01.98000888',

--- a/server/ngwmn/tests/services/test_ngwmn.py
+++ b/server/ngwmn/tests/services/test_ngwmn.py
@@ -268,8 +268,8 @@ class TestWellLogResults(TestCase):
                     },
                     'shape': {
                         'coordinates': {
-                            'start': 0,
-                            'end': 25
+                            'start': 0.0,
+                            'end': 25.0
                         },
                         'dimension': '1',
                         'unit': 'ft'
@@ -297,8 +297,8 @@ class TestWellLogResults(TestCase):
                     },
                     'shape': {
                         'coordinates': {
-                            'start': 25,
-                            'end': 56
+                            'start': 25.0,
+                            'end': 56.0
                         },
                         'dimension': '1',
                         'unit': 'ft'
@@ -326,28 +326,29 @@ class TestWellLogResults(TestCase):
                     },
                     'shape': {
                         'coordinates': {
-                            'start': 56,
-                            'end': 155
+                            'start': 56.0,
+                            'end': 155.0
                         },
                         'dimension': '1',
                         'unit': 'ft'
                     }
                 }],
-                'casings': [{
+                'construction': [{
+                    'type': 'casing',
                     'position': {
                         'coordinates': {
-                            'start': 0,
+                            'start': 0.0,
                             'end': 80.9
                         },
                         'unit': 'ft'
                     },
                     'material': 'PVC',
                     'diameter': {
-                        'value': 16,
+                        'value': 16.0,
                         'unit': 'in'
                     }
-                }],
-                'screens': [{
+                }, {
+                    'type': 'screen',
                     'diameter': {
                         'value': None,
                         'unit': 'in',
@@ -361,6 +362,7 @@ class TestWellLogResults(TestCase):
                         'unit': 'ft'
                     }
                 }, {
+                    'type': 'screen',
                     'diameter': {
                         'value': None,
                         'unit': 'in'
@@ -373,7 +375,7 @@ class TestWellLogResults(TestCase):
                         },
                         'unit': 'ft'
                     }
-                }],
+                }]
             })
 
 

--- a/server/ngwmn/tests/services/test_ngwmn.py
+++ b/server/ngwmn/tests/services/test_ngwmn.py
@@ -230,12 +230,12 @@ class TestWellLogResults(TestCase):
                 },
                 'elevation': {
                     'unit': 'ft',
-                    'value': '1950',
+                    'value': 1950.0,
                     'scheme': 'NAVD88',
                 },
                 'well_depth': {
                     'unit': 'ft',
-                    'value': '214'
+                    'value': 214.0
                 },
                 'water_use': 'urn:OGC:unknown',
                 'link': {
@@ -265,11 +265,11 @@ class TestWellLogResults(TestCase):
                     },
                     'shape': {
                         'coordinates': {
-                            'start': '0.00',
-                            'end': '25.00'
+                            'start': 0,
+                            'end': 25
                         },
                         'dimension': '1',
-                        'unit': 'Unknown'
+                        'unit': 'ft'
                     }
                 }, {
                     'method': 'borehole',
@@ -294,11 +294,11 @@ class TestWellLogResults(TestCase):
                     },
                     'shape': {
                         'coordinates': {
-                            'start': '25.00',
-                            'end': '56.00'
+                            'start': 25,
+                            'end': 56
                         },
                         'dimension': '1',
-                        'unit': 'Unknown'
+                        'unit': 'ft'
                     }
                 }, {
                     'method': 'borehole',
@@ -323,18 +323,18 @@ class TestWellLogResults(TestCase):
                     },
                     'shape': {
                         'coordinates': {
-                            'start': '56.00',
-                            'end': '155.00'
+                            'start': 56,
+                            'end': 155
                         },
                         'dimension': '1',
-                        'unit': 'Unknown'
+                        'unit': 'ft'
                     }
                 }],
                 'casings': [{
                     'position': {
                         'coordinates': {
-                            'start': '0',
-                            'end': '80.9'
+                            'start': 0,
+                            'end': 80.9
                         },
                         'unit': 'ft'
                     },
@@ -352,8 +352,8 @@ class TestWellLogResults(TestCase):
                     'material': 'PVC',
                     'position': {
                         'coordinates': {
-                            'start': '80.8',
-                            'end': '90.8'
+                            'start': 80.8,
+                            'end': 90.8
                         },
                         'unit': 'ft'
                     }
@@ -365,8 +365,8 @@ class TestWellLogResults(TestCase):
                     'material': 'PVC',
                     'position': {
                         'coordinates': {
-                            'end': '212.8',
-                            'start': '152.8'
+                            'end': 212.8,
+                            'start': 152.8
                         },
                         'unit': 'ft'
                     }

--- a/server/ngwmn/tests/services/test_ngwmn.py
+++ b/server/ngwmn/tests/services/test_ngwmn.py
@@ -343,7 +343,7 @@ class TestWellLogResults(TestCase):
                     },
                     'material': 'PVC',
                     'diameter': {
-                        'value': '16',
+                        'value': 16,
                         'unit': 'in'
                     }
                 }],

--- a/server/ngwmn/views.py
+++ b/server/ngwmn/views.py
@@ -7,7 +7,7 @@ from flask import abort, jsonify, render_template
 
 from . import __version__, app
 from .services.ngwmn import (
-    get_features, get_iddata, get_water_quality_activities, get_well_log)
+    get_features, get_iddata, get_water_quality, get_well_log)
 from .services.sifta import get_cooperators
 
 
@@ -60,13 +60,14 @@ def site_page(agency_cd, location_id):
     latitude, longitude = geolocation.split(' ')
     summary = get_features(latitude, longitude)
 
-    water_quality_activities = get_water_quality_activities(agency_cd, location_id)
+    wq = get_water_quality(agency_cd, location_id)
     well_log = get_well_log(agency_cd, location_id)
 
     return render_template(
         'site_location.html',
         cooperators=get_cooperators(location_id),
         feature=summary['features'][0]['properties'],
-        water_quality_activities=water_quality_activities,
+        organization=wq['organization']['name'] if 'organization' in wq else None,
+        water_quality_activities=wq.get('activities') or [],
         well_log=well_log
     ), 200

--- a/server/ngwmn/views.py
+++ b/server/ngwmn/views.py
@@ -59,16 +59,22 @@ def site_page(agency_cd, location_id):
     geolocation = geolocation_element.text
     latitude, longitude = geolocation.split(' ')
     summary = get_features(latitude, longitude)
+
+    water_quality = get_water_quality(agency_cd, location_id)
+    well_log = get_well_log(agency_cd, location_id)
+
     feature = summary['features'][0]['properties']
 
-    wq = get_water_quality(agency_cd, location_id)
-    well_log = get_well_log(agency_cd, location_id)
+    if 'organization' in water_quality:
+        organization = water_quality['organization']['name']
+    else:
+        organization = feature.get('AGENCY_NM')
 
     return render_template(
         'site_location.html',
         cooperators=get_cooperators(location_id),
         feature=feature,
-        organization=wq['organization']['name'] if 'organization' in wq else feature.get('AGENCY_NM'),
-        water_quality_activities=wq.get('activities') or [],
+        organization=organization,
+        water_quality_activities=water_quality.get('activities') or [],
         well_log=well_log
     ), 200

--- a/server/ngwmn/views.py
+++ b/server/ngwmn/views.py
@@ -59,6 +59,7 @@ def site_page(agency_cd, location_id):
     geolocation = geolocation_element.text
     latitude, longitude = geolocation.split(' ')
     summary = get_features(latitude, longitude)
+    feature = summary['features'][0]['properties']
 
     wq = get_water_quality(agency_cd, location_id)
     well_log = get_well_log(agency_cd, location_id)
@@ -66,8 +67,8 @@ def site_page(agency_cd, location_id):
     return render_template(
         'site_location.html',
         cooperators=get_cooperators(location_id),
-        feature=summary['features'][0]['properties'],
-        organization=wq['organization']['name'] if 'organization' in wq else None,
+        feature=feature,
+        organization=wq['organization']['name'] if 'organization' in wq else feature.get('AGENCY_NM'),
         water_quality_activities=wq.get('activities') or [],
         well_log=well_log
     ), 200


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Description
-----------
This adds a to-scale drawing over the lithology chart of the well construction data (screens and casings). If diameters of the elements are not available, adjacent diameters are used. Water levels are drawn inside the well using a clipPath.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
