### PR TITLE
Remove duplicate service call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added well log tables
 - Added well construction drawing (screens, casings)
 - Fill lithology layers with FGDC Digital Cartographic Standard patterns
+### Changed
+- Removed duplicate service call to retrieve well log data

--- a/server/ngwmn/services/__init__.py
+++ b/server/ngwmn/services/__init__.py
@@ -5,7 +5,7 @@ from ngwmn import app
 
 class ServiceException(Exception):
     """
-    Exception to be raised by external-service calls when an service error is
+    Exception to be raised by external-service calls when a service error is
     encountered. This exception will be passed to the end-user in the form of
     a response with the given status code, message, and dict payload.
     """

--- a/server/ngwmn/tests/services/test_sifta.py
+++ b/server/ngwmn/tests/services/test_sifta.py
@@ -11,15 +11,15 @@ import requests_mock
 from ngwmn.services import sifta
 
 
-MOCK_RESPONSE = """
+MOCK_SIFTA_RESPONSE = """
 {"Site": "06864000", "Date": "6/19/2018", "Customers":[{"Name":"Kansas Water Office","URL":"http://www.kwo.org/","IconURL":"http://water.usgs.gov/customer/icons/6737.gif"},{"Name":"USGS - Cooperative Matching Funds","URL":"http://water.usgs.gov/coop/","IconURL":"http://water.usgs.gov/customer/icons/usgsIcon.gif"}]}
 """
-MOCK_CUSTOMER_LIST = json.loads(MOCK_RESPONSE)['Customers']
+MOCK_CUSTOMER_LIST = json.loads(MOCK_SIFTA_RESPONSE)['Customers']
 
 
 def test_sifta_response():
     with requests_mock.mock() as req:
-        req.get(requests_mock.ANY, text=MOCK_RESPONSE)
+        req.get(requests_mock.ANY, text=MOCK_SIFTA_RESPONSE)
         cooperators = sifta.get_cooperators('12345')
         assert cooperators == MOCK_CUSTOMER_LIST
 

--- a/server/ngwmn/views.py
+++ b/server/ngwmn/views.py
@@ -8,8 +8,7 @@ from functools import reduce
 from flask import abort, jsonify, render_template
 
 from . import __version__, app
-from .services.ngwmn import (
-    get_features, get_iddata, get_water_quality, get_well_log)
+from .services.ngwmn import get_features, get_water_quality, get_well_log
 from .services.sifta import get_cooperators
 
 
@@ -53,17 +52,15 @@ def site_page(agency_cd, location_id):
 
     """
 
-    root = get_iddata('well_log', agency_cd, location_id)
-    if root is None or 'gml' not in root.nsmap.keys():
+    well_log = get_well_log(agency_cd, location_id)
+    if not well_log:
         return abort(404)
 
-    geolocation_element = root.find('.//gml:Point/gml:pos', namespaces=root.nsmap)
-    geolocation = geolocation_element.text
-    latitude, longitude = geolocation.split(' ')
-    summary = get_features(latitude, longitude)
-
+    summary = get_features(
+        well_log['location']['latitude'],
+        well_log['location']['longitude']
+    )
     water_quality = get_water_quality(agency_cd, location_id)
-    well_log = get_well_log(agency_cd, location_id)
 
     feature = summary['features'][0]['properties']
 


### PR DESCRIPTION
This removes a duplicate service call to get well_log data, which necessitated some changes to the unit tests. That surfaced that fact that some of the service calls were making live http requests in the test suite; using requests_mock on all the view tests guarantees that doesn't happen.

Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
If no JIRA ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
