### PR TITLE
Fix service mismatch and add error handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added providers view which provides a list of available providers
 - Added provider view which shows information about an individual provider
 - Added sites view which provides a list of sites for a provider
+- Added error template for backing service calls, 404s, and 500s
 
 ### Changed
 - The site page route was changed

--- a/server/config.py
+++ b/server/config.py
@@ -5,8 +5,6 @@ Application configuration settings
 DEBUG = False
 
 SERVICE_ROOT = 'https://cida.usgs.gov'
-# ngwmn_cache service root happens to be the same as the ngwmn root, but does not have to be
-SERVICE_ROOT_CACHE = SERVICE_ROOT
 
 CONFLUENCE_URL = 'https://my.usgs.gov/confluence/'
 

--- a/server/ngwmn/__init__.py
+++ b/server/ngwmn/__init__.py
@@ -1,7 +1,7 @@
 """
 Initialize the NGWMN UI application
 """
-from flask import Flask
+from flask import Flask, render_template
 
 
 __version__ = '0.3.0dev'
@@ -14,6 +14,19 @@ try:
     app.config.from_pyfile('config.py')
 except FileNotFoundError:
     pass
+
+
+@app.errorhandler(404)
+@app.errorhandler(500)
+def handle_service_exception(error):
+    return render_template(
+        'error.html',
+        error={
+            'message': error.description,
+            'status_code': error.code,
+            'status_code_str': error.name
+        }
+    ), error.code
 
 
 from . import views # pylint: disable=C0413

--- a/server/ngwmn/services/__init__.py
+++ b/server/ngwmn/services/__init__.py
@@ -1,4 +1,6 @@
-from flask import jsonify
+from http.client import responses
+
+from flask import render_template
 
 from ngwmn import app
 
@@ -22,7 +24,8 @@ class ServiceException(Exception):
         return {
             **self.payload,
             'message': self.message,
-            'status_code': self.status_code
+            'status_code': self.status_code,
+            'status_code_str': responses[self.status_code]
         }
 
 
@@ -31,6 +34,7 @@ def handle_service_exception(error):
     """
     Capture raised ServiceExceptions and return the appropriate status code.
     """
-    response = jsonify(error.to_dict())
-    response.status_code = error.status_code
-    return response
+    return render_template(
+        'error.html',
+        error=error.to_dict()
+    ), error.status_code

--- a/server/ngwmn/services/ngwmn.py
+++ b/server/ngwmn/services/ngwmn.py
@@ -14,7 +14,6 @@ from ngwmn.services.lithology_parser import classify_material, get_colors
 from ngwmn.xml_utils import parse_xml
 
 SERVICE_ROOT = app.config.get('SERVICE_ROOT')
-SERVICE_ROOT_CACHE = app.config.get('SERVICE_ROOT_CACHE')
 
 
 def get_iddata(request, agency_cd, location_id, service_root=SERVICE_ROOT):
@@ -408,7 +407,7 @@ def get_sites(agency_cd, service_root=SERVICE_ROOT):
     return list(map(lambda x: convert_keys_and_booleans(x.get('properties', {})), features))
 
 
-def get_statistic(agency_cd, site_no, stat_type, service_root=SERVICE_ROOT_CACHE):
+def get_statistic(agency_cd, site_no, stat_type, service_root=SERVICE_ROOT):
     """
     fetches the statistics from the ngwmn cache
 

--- a/server/ngwmn/templates/error.html
+++ b/server/ngwmn/templates/error.html
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div class="usa-width-one-whole">
-        <h1>{{ error.message | title }}</h1>
-        <h2>{{ error.status_code_str }} ({{ error.status_code }})</h2>
+        <h1>{{ error.status_code_str | title }} ({{ error.status_code }})</h1>
+        <h2>{{ error.message }}</h2>
     </div>
 {% endblock content %}

--- a/server/ngwmn/templates/error.html
+++ b/server/ngwmn/templates/error.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <div class="usa-width-one-whole">
+        <h1>{{ error.message | title }}</h1>
+        <h2>{{ error.status_code_str }} ({{ error.status_code }})</h2>
+    </div>
+{% endblock content %}

--- a/server/ngwmn/tests/test_views.py
+++ b/server/ngwmn/tests/test_views.py
@@ -15,7 +15,6 @@ from .services.mock_data import MOCK_SIFTA_RESPONSE, MOCK_WELL_LOG_RESPONSE, MOC
     MOCK_OVERALL_STATS, MOCK_MONTHLY_STATS, MOCK_SITE_INFO
 
 SERVICE_ROOT = app.config.get('SERVICE_ROOT')
-SERVICE_ROOT_CACHE = app.config.get('SERVICE_ROOT_CACHE')
 COOP_SERVICE_PATTERN = app.config['COOPERATOR_SERVICE_PATTERN']
 
 
@@ -33,9 +32,9 @@ class TestWellPageView(TestCase):
         self.site_loc_url = '/provider/{0}/site/{1}/'.format(_agency_cd, _location_id)
 
         _stats_url = '/'.join(['ngwmn_cache', 'direct', 'json'])
-        self.site_info_url = '/'.join([SERVICE_ROOT_CACHE, _stats_url, 'site-info', _agency_cd, _location_id])
-        self.stats_overall_url = '/'.join([SERVICE_ROOT_CACHE, _stats_url, 'wl-overall', _agency_cd, _location_id])
-        self.stats_monthly_url = '/'.join([SERVICE_ROOT_CACHE, _stats_url, 'wl-monthly', _agency_cd, _location_id])
+        self.site_info_url = '/'.join([SERVICE_ROOT, _stats_url, 'site-info', _agency_cd, _location_id])
+        self.stats_overall_url = '/'.join([SERVICE_ROOT, _stats_url, 'wl-overall', _agency_cd, _location_id])
+        self.stats_monthly_url = '/'.join([SERVICE_ROOT, _stats_url, 'wl-monthly', _agency_cd, _location_id])
         self.mock_site_info_json = json.dumps(MOCK_SITE_INFO)
         self.mock_overall_json = json.dumps(MOCK_OVERALL_STATS)
         self.mock_monthly_json = json.dumps(MOCK_MONTHLY_STATS)


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

NGWMN-1788
---------------
This removes a distinction between the "service root" and "cache service root", because the site page view assumes that it's the data from various service calls are coming from the same database. Also, added in an error template that inherits from the site base template.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
