### PR TITLE
Ngwmn 1799 show number of pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 -   Changed pagination to include start and end points
 
+### Fixed
+-   Added 'utf-8' decoding parameter to open method for lithology parser to prevent failure during Jenkins build
+
 ## [0.5.0][]
 ### Added
 -   Added FLDEP Logo to images/provider_logos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 -   Added y axes to well diagram for depth and elevation
 
+### Changed
+-   Changed pagination to include start and end points
+
 ## [0.5.0][]
 ### Added
 -   Added FLDEP Logo to images/provider_logos

--- a/assets/src/scripts/components/water-level-table/index.js
+++ b/assets/src/scripts/components/water-level-table/index.js
@@ -49,7 +49,6 @@ const drawTableBody = function(table, waterLevels, tbody) {
             innerWindow: 2,
             right: 1
         }]
-
     };
     new List('water-levels-div', options, samples);
 

--- a/assets/src/scripts/components/water-level-table/index.js
+++ b/assets/src/scripts/components/water-level-table/index.js
@@ -44,7 +44,12 @@ const drawTableBody = function(table, waterLevels, tbody) {
         valueNames: valueNames,
         item: `<tr>${item}</tr>`,
         page: 30,
-        pagination: true
+        pagination: [{
+            left: 1,
+            innerWindow: 2,
+            right: 1
+        }]
+
     };
     new List('water-levels-div', options, samples);
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

NGWMN-1799 Show Number of Pages
-----------
Added options to current pagination tool so that the total number of pages show.

Description
-----------
Currently site pages condense water-level data into tables and user can see the links to the next few pages of tables.  However, user cannot see how much data (or how many smaller tables) exist for the site.  SOGW would like to add that feature.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
