### PR TITLE
NGMWN-1787 well depth overrides empty construction elements

### DIFF
--- a/assets/src/scripts/components/graph/state/well-log.js
+++ b/assets/src/scripts/components/graph/state/well-log.js
@@ -45,13 +45,14 @@ export const getWellLogEntries = memoize(opts => createSelector(
  */
 export const getWellLogEntriesExtentY = memoize(opts => createSelector(
     getWellLogEntries(opts),
-    (wellLogEntries) => {
+    getSiteWellDepth(opts.agencyCode, opts.siteId),
+    (wellLogEntries, wellDepth) => {
         if (wellLogEntries.length === 0) {
-            return [0, 0];
+            return [0, Math.max(0,wellDepth)];
         }
         return [
             Math.min(...wellLogEntries.map(entry => entry.shape.coordinates.start)),
-            Math.max(...wellLogEntries.map(entry => entry.shape.coordinates.end))
+            Math.max(...wellLogEntries.map(entry => entry.shape.coordinates.end), wellDepth)
         ];
     }
 ));

--- a/assets/src/scripts/components/graph/state/well-log.spec.js
+++ b/assets/src/scripts/components/graph/state/well-log.spec.js
@@ -54,6 +54,7 @@ describe('graph component well log state', () => {
     });
 
     describe('getWellLogEntriesExtentY', () => {
+        const wellDepth = 3;
         const logEntries = [{
             shape: {
                 coordinates: {
@@ -65,21 +66,21 @@ describe('graph component well log state', () => {
             shape: {
                 coordinates: {
                     start: '2',
-                    end: '3'
+                    end: '4'
                 }
             }
         }];
 
         it('works', () => {
-            expect(getWellLogEntriesExtentY({}).resultFunc(logEntries)).toEqual([1, 3]);
+            expect(getWellLogEntriesExtentY({}).resultFunc(logEntries,wellDepth)).toEqual([1, 4]);
         });
 
         it('works with empty log', () => {
-            expect(getWellLogEntriesExtentY({}).resultFunc([])).toEqual([0, 0]);
+            expect(getWellLogEntriesExtentY({}).resultFunc([],wellDepth)).toEqual([0, 3]);
         });
 
         it('works with mock state', () => {
-            expect(getWellLogEntriesExtentY(mockOpts)(getMockStore().getState())).not.toBe(null);
+            expect(getWellLogEntriesExtentY(mockOpts)(getMockStore().getState(),wellDepth)).not.toBe(null);
         });
     });
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Well depth overrides empty construction elements

Description
-----------
When there were not construction elements the function returned [0,0] even though there could be (and usually is) a well depth provided. This update uses the max of the construction or well depth.

This was not included in the original PR because without the axis label (which now exist) it was not an obvious issue.

Additionally, this issue seems related to the water level rendering issue. I checked and it does not resolve that. It still might be related.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
