### PR TITLE
NGMWN-1852 fix typo alignment of values and headers for min/max water levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 -   Added 'utf-8' decoding parameter to open method for lithology parser to prevent failure during Jenkins build
+-   Fixed (swapped) column header labels for Min/Max overall water level.
 
 ### Changed
 -   Changed pagination to include start and end points

--- a/server/ngwmn/templates/site_location.html
+++ b/server/ngwmn/templates/site_location.html
@@ -191,9 +191,9 @@
                         <caption>Overall Water Level Statistics ({{ stats.overall.alt_datum }})</caption>
                         <thead>
                             <tr class="light">
-                                <th>Highest Water Level</th>
-                                <th>Median Water Level</th>
                                 <th>Lowest Water Level</th>
+                                <th>Median Water Level</th>
+                                <th>Highest Water Level</th>
                                 <th>First Measurement Date</th>
                                 <th>Last Measurement Date</th>
                                 <th>Number of Measurements</th>


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Column headers did not match location of data.

Description
-----------
This fixes a minor typo with somewhat major consequences. NGWMN-1875 is actually about the latest percentile but I was asked make this quick fix within. A bit of scope increase but not too complex. It is so trivial that no new test are warranted.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
