### PR TITLE
change from localhost to tier host for stats

### DIFF
--- a/assets/src/scripts/services/statistics.js
+++ b/assets/src/scripts/services/statistics.js
@@ -1,8 +1,8 @@
 import { post } from '../lib/ajax';
 
 // median water level URL
-//const MWL_URL = `${config.SERVICE_ROOT}/statistics/calculate`;
-const MWL_URL = 'http://localhost:8777/statistics/calculate';
+const MWL_URL = `${config.SERVICE_ROOT}/statistics/calculate`;
+// const MWL_URL = 'http://localhost:8777/statistics/calculate';
 
 
 /**


### PR DESCRIPTION
Title
-----------
change from localhost to tier host for stats

Description
-----------
The stats section has a subsection for median water levels that was calling localhost from js. That will not work. I presume that I was either testing locally or thought I was in the server-side section (nodejs).

