### PR TITLE
change from localhost to tier host for stats (import config)

### DIFF
--- a/assets/src/scripts/services/statistics.js
+++ b/assets/src/scripts/services/statistics.js
@@ -1,4 +1,5 @@
 import { post } from '../lib/ajax';
+import config from 'ngwmn/config';
 
 // median water level URL
 const MWL_URL = `${config.SERVICE_ROOT}/statistics/calculate`;


### PR DESCRIPTION

Title
-----------
import the config to change from localhost to tier host for stats

Description
-----------
The stats section has a subsection for median water levels that was calling localhost from js. That will not work. I presume that I was either testing locally or thought I was in the server-side section (nodejs).

