### PR TITLE
change from localhost to tier host for stats with double URL (double statistics)

### DIFF
--- a/assets/src/scripts/services/statistics.js
+++ b/assets/src/scripts/services/statistics.js
@@ -2,7 +2,7 @@ import { post } from '../lib/ajax';
 import config from 'ngwmn/config';
 
 // median water level URL
-const MWL_URL = `${config.SERVICE_ROOT}/statistics/calculate`;
+const MWL_URL = `${config.SERVICE_ROOT}/statistics/statistics/calculate`;
 // const MWL_URL = 'http://localhost:8777/statistics/calculate';
 
 


### PR DESCRIPTION
Title
change from localhost to tier host for stats with double URL.

Description
The stats section has a subsection for median water levels that was calling localhost from js. That will not work. I presume that I was either testing locally or thought I was in the server-side section (nodejs).

The double URL is because deploying within tomcat doubles up the /statistics portion of the URL.
/statistics/calculate becomes /statistics/statistics/calculate 