### PR TITLE
add log for url

### DIFF
--- a/server/ngwmn/services/sifta.py
+++ b/server/ngwmn/services/sifta.py
@@ -36,6 +36,7 @@ def get_cooperators(site_no):
 
     try:
         response = requests.get(url)
+        app.logger.debug('attempting to contact SIFTA services with this url: %s', url)
     except requests.exceptions.RequestException as err:
         app.logger.error(str(err))
         return []


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Adding a Log Statement to Debug Server HTTPS issue
-----------
Despite working fine locally, the call to get the cooperator logos from the SIFTA service will not work on the server and is giving the error:
[Mon Nov 30 14:37:34.804473 2020] [:error] [pid 96454:tid 140247328532224] [remote 10.211.162.87:23504] [2020-11-30 14:37:34,804] ERROR in sifta: HTTPSConnectionPool(host='sifta.water.usgs.gov', port=443): M
ax retries exceeded with url: /Services/REST/Site/CustomerFunding.ashx?SiteNumber=282532081075601&StartDate=10/1/2020&EndDate=11/30/2020 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection obj
ect at 0x7f8dcd6c4cc0>: Failed to establish a new connection: [Errno 113] No route to host',))

this is and attempt to debug the issue.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
