### PR TITLE
make name a link for non-usgs providers

### DIFF
--- a/server/ngwmn/templates/site_location.html
+++ b/server/ngwmn/templates/site_location.html
@@ -281,7 +281,11 @@
                      height="50">
             </a>
             <figcaption>
+                <a href="{{ url_for('provider', agency_cd=feature.AGENCY_CD) }}"
+                   target="_blank"
+                   rel="noopener">
                 {{ feature.AGENCY_NM }}
+                </a>
             </figcaption>
         </figure>
     {% endif %}
@@ -319,7 +323,7 @@
                      height="50">
                 <figcaption>
                     <a class="usa-link"
-                        href="{{ url_for('provider', agency_cd='USGS') }}"
+                       href="{{ url_for('provider', agency_cd='USGS') }}"
                        target="_blank"
                        rel="noopener">
                         US Geological Survey


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Make Figure Caption a Link for Non-USGS Locations
-----------
This is a tiny change. Makes the figure caption for non USGS locations a hyperlink. This changed the existing figure caption to match the new logos for SIFTA and also matches the functionality of the WDFN new monitoring location pages.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
