### PR TITLE
Update dependency feedparser to 6x

### DIFF
--- a/server/ngwmn/tests/services/test_confluence.py
+++ b/server/ngwmn/tests/services/test_confluence.py
@@ -11,7 +11,9 @@ from ngwmn.services.confluence import pull_feed, confluence_url
 
 class TestPullFeed(TestCase):
 
-    def test_bad_url(self):
+    @mock.patch('ngwmn.services.confluence.feedparser.parse')
+    def test_bad_url(self,  m_parse):
+        m_parse.return_value = BLANK_FEED
         self.assertEqual(pull_feed('http:fakeserver.com'), '')
 
     @mock.patch('ngwmn.services.confluence.feedparser.parse')
@@ -27,6 +29,10 @@ class TestConfluenceUrl(TestCase):
     def test_for_label_string(self):
         self.assertIn('labelString=ngwmn_provider_ABCDE_mycontent', confluence_url('ABCDE', 'mycontent'))
 
+
+BLANK_FEED = feedparser.parse('''
+<html><head></head><body>invalid-provider is not a valid agency code</body></html>
+''')
 
 MOCK_FEED = feedparser.parse('''<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.9.3
 defusedxml==0.6.0
-feedparser==5.2.1
+feedparser==6.0.2
 Flask==1.1.2
 fuzzywuzzy[speedup]==0.18.0
 lxml==4.6.2


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Updates FeedParser from 5.2.1 to 6.0.2
-----------
This 'major' version change of FeedParser removes support for Python versions below 3.6. The update didn't seem to affect application function, but did break one test. The '.parse' method now seems to require some sort of response, while before it tolerated receiving no response at all.  I added what emulates a bad provider URL. 

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
